### PR TITLE
Add new Saarland RSS feeds

### DIFF
--- a/src/data/settings.json
+++ b/src/data/settings.json
@@ -8,7 +8,12 @@
     "fahrrad": "https://www.fahrrad.saarland/feed/",
     "polizei": "https://www.presseportal.de/rss/polizei/laender/13.rss2",
     "tagesschau": "https://www.tagesschau.de/inland/regional/saarland/index~rss2.xml",
-    "dudplaner": "https://www.dudoplaner.de/feed/"
+    "dudplaner": "https://www.dudoplaner.de/feed/",
+    "saarbruecker-zeitung": "https://www.saarbruecker-zeitung.de/feed.rss",
+    "salue-news": "https://www.salue.de/nachrichten/news.xml",
+    "salue-staus": "https://www.salue.de/stausblitzer/staus.xml",
+    "mfw-events": "https://www.saarland.de/mfw/DE/aktuelles/rss-feed/_feeds/veranstaltungen_feed.xml",
+    "mfw-pressemitteilungen": "https://www.saarland.de/mfw/DE/aktuelles/rss-feed/_feeds/pressemitteilungen_feed.xml"
   },
   "feed_hashtags": ["news", "saarland"],
   "min_freshness_hours": 24,


### PR DESCRIPTION
## Summary
- add several RSS feeds related to Saarland

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845b93e5ab083208b20fed97dc481fa