### PR TITLE
Remove salue.de feeds

### DIFF
--- a/src/data/settings.json
+++ b/src/data/settings.json
@@ -10,8 +10,6 @@
     "tagesschau": "https://www.tagesschau.de/inland/regional/saarland/index~rss2.xml",
     "dudplaner": "https://www.dudoplaner.de/feed/",
     "saarbruecker-zeitung": "https://www.saarbruecker-zeitung.de/feed.rss",
-    "salue-news": "https://www.salue.de/nachrichten/news.xml",
-    "salue-staus": "https://www.salue.de/stausblitzer/staus.xml",
     "mfw-events": "https://www.saarland.de/mfw/DE/aktuelles/rss-feed/_feeds/veranstaltungen_feed.xml",
     "mfw-pressemitteilungen": "https://www.saarland.de/mfw/DE/aktuelles/rss-feed/_feeds/pressemitteilungen_feed.xml"
   },


### PR DESCRIPTION
## Summary
- remove the `salue-news` and `salue-staus` feeds from settings

## Testing
- `npm test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_6849d8a366a4832080904e1e61ae3c02