### PR TITLE
Use article descriptions for improved story similarity detection

### DIFF
--- a/src/helper/similarity.test.ts
+++ b/src/helper/similarity.test.ts
@@ -10,7 +10,11 @@ import {
 } from "./similarity.js";
 
 function makeArticle(
-  overrides: Partial<ClusterArticle> & { title?: string; feedKey?: string }
+  overrides: Partial<ClusterArticle> & {
+    title?: string;
+    feedKey?: string;
+    contentSnippet?: string;
+  }
 ): ClusterArticle {
   return {
     id: overrides.id ?? Math.random().toString(36).slice(2),
@@ -18,6 +22,7 @@ function makeArticle(
       title: overrides.title ?? "Test Article",
       link: `https://example.com/${overrides.id ?? "test"}`,
       "dc:creator": "",
+      contentSnippet: overrides.contentSnippet,
       ...(overrides.article as any),
     },
     feedKey: overrides.feedKey ?? "feed-a",
@@ -148,6 +153,20 @@ describe("storySimilarity — same story detection", () => {
     // Identical titles but 24h apart → jaccard=1.0, time=0.0 → 0.7
     expect(sim).toBeCloseTo(0.7, 5);
   });
+
+  it("uses description to detect same story when titles share few tokens", () => {
+    // Simulate two sources covering the same road accident with very different headlines.
+    // Title overlap is minimal, but descriptions overlap substantially.
+    const sim = storySimilarity(
+      "Unfall auf der A6",
+      "Sperrung wegen Verkehrsgeschehen",
+      now,
+      oneHourLater,
+      "Schwerer Unfall auf der Autobahn A6 bei Saarbrücken führt zu Vollsperrung. Zwei Fahrzeuge kollidierten.",
+      "Die A6 bei Saarbrücken ist nach einem schweren Unfall vollgesperrt. Zwei Autos kollidierten auf der Autobahn."
+    );
+    expect(sim).toBeGreaterThanOrEqual(0.4);
+  });
 });
 
 describe("clusterArticles", () => {
@@ -251,6 +270,36 @@ describe("clusterArticles", () => {
     for (const [, cluster] of clusters) {
       expect(cluster.length).toBe(1);
     }
+  });
+
+  it("clusters articles from different feeds with differing titles but similar descriptions", () => {
+    // Regression: two sources covered the same road accident but with headlines
+    // that share almost no tokens. Without description-based similarity they would
+    // end up in separate clusters and both get posted.
+    const now = new Date("2024-06-15T10:00:00Z");
+    const articles: ClusterArticle[] = [
+      makeArticle({
+        id: "1",
+        title: "Unfall auf der A6",
+        feedKey: "feed-a",
+        pubDate: now.toISOString(),
+        contentSnippet:
+          "Schwerer Unfall auf der Autobahn A6 bei Saarbrücken führt zu Vollsperrung. Zwei Fahrzeuge kollidierten.",
+      }),
+      makeArticle({
+        id: "2",
+        title: "Sperrung wegen Verkehrsgeschehen",
+        feedKey: "feed-b",
+        pubDate: new Date(now.getTime() + 20 * 60000).toISOString(),
+        contentSnippet:
+          "Die A6 bei Saarbrücken ist nach einem schweren Unfall vollgesperrt. Zwei Autos kollidierten auf der Autobahn.",
+      }),
+    ];
+
+    const clusters = clusterArticles(articles, 0.4);
+    expect(clusters.size).toBe(1);
+    const allArticles = Array.from(clusters.values())[0]!;
+    expect(allArticles.length).toBe(2);
   });
 
   it("returns a single-article cluster for a single input", () => {

--- a/src/helper/similarity.ts
+++ b/src/helper/similarity.ts
@@ -67,10 +67,14 @@ export function storySimilarity(
   titleA: string,
   titleB: string,
   dateA: Date,
-  dateB: Date
+  dateB: Date,
+  contentA?: string,
+  contentB?: string
 ): number {
-  const tokensA = tokenize(titleA);
-  const tokensB = tokenize(titleB);
+  const textA = contentA ? `${titleA} ${contentA}` : titleA;
+  const textB = contentB ? `${titleB} ${contentB}` : titleB;
+  const tokensA = tokenize(textA);
+  const tokensB = tokenize(textB);
   const jaccard = jaccardSimilarity(tokensA, tokensB);
   const timeSim = timeProximityScore(dateA, dateB);
   return 0.7 * jaccard + 0.3 * timeSim;
@@ -119,8 +123,12 @@ export function clusterArticles(
       const dateB = articles[j].pubDate
         ? new Date(articles[j].pubDate!)
         : new Date();
+      // Include up to 500 chars of the article description to catch same-story
+      // articles whose headlines are phrased very differently across sources.
+      const descA = (articles[i].article.contentSnippet ?? "").slice(0, 500);
+      const descB = (articles[j].article.contentSnippet ?? "").slice(0, 500);
 
-      const sim = storySimilarity(titleA, titleB, dateA, dateB);
+      const sim = storySimilarity(titleA, titleB, dateA, dateB, descA, descB);
       if (sim >= threshold) {
         union(i, j);
       }


### PR DESCRIPTION
## Summary
Enhanced the story similarity detection algorithm to incorporate article descriptions (content snippets) alongside titles. This allows the clustering system to correctly identify duplicate stories even when different news sources use significantly different headlines.

## Key Changes
- **Modified `storySimilarity()` function**: Added optional `contentA` and `contentB` parameters that are concatenated with titles before tokenization. This allows the similarity calculation to consider both headline and description text.
- **Updated `clusterArticles()` function**: Now extracts up to 500 characters from each article's `contentSnippet` field and passes it to `storySimilarity()` for improved matching.
- **Enhanced test helper**: Updated `makeArticle()` test utility to support the `contentSnippet` property in article overrides.
- **Added regression tests**: 
  - Unit test for `storySimilarity()` demonstrating detection of same story with minimal title overlap but substantial description overlap
  - Integration test for `clusterArticles()` showing two articles with different headlines but similar descriptions are correctly clustered together

## Implementation Details
- Description text is limited to 500 characters to balance matching quality with performance
- The similarity weighting remains unchanged (70% Jaccard similarity, 30% time proximity)
- Descriptions are optional; the function gracefully handles missing content snippets
- Test case uses a real-world scenario: two German news sources covering the same road accident with different headlines but overlapping descriptions

https://claude.ai/code/session_01LufGw7ZGLKjF8A8mEjQyD9