### PR TITLE
fix: dedup follow-up quote toots by normalized URL

### DIFF
--- a/src/helper/clusterFormatter.test.ts
+++ b/src/helper/clusterFormatter.test.ts
@@ -299,4 +299,94 @@ describe("formatThreadReply", () => {
     const linkMatches = result.match(/https:\/\/shared\.com\/link/g);
     expect(linkMatches?.length).toBe(1);
   });
+
+  // ---- Regression tests for the daily re-toot bug ----
+  //
+  // Background: the `verbraucherzentrale` feed re-emits the same article
+  // for weeks, sometimes with a cosmetic URL tweak (trailing slash,
+  // tracking param, fragment). `formatThreadReply` was comparing links
+  // with raw string equality, so the variant was treated as "new" and
+  // included in the quote post even though the primary toot already
+  // linked the same page. These tests pin that behavior shut.
+
+  it("treats trailing-slash URL as duplicate of no-slash URL in excludeLinks", () => {
+    const originalLinks = [
+      "https://www.verbraucherzentrale-saarland.de/verfahren/stadtsparkasse-muenchen",
+    ];
+    const articles = [
+      makeArticle({
+        id: "1",
+        title: "Klage gegen Stadtsparkasse München",
+        link: "https://www.verbraucherzentrale-saarland.de/verfahren/stadtsparkasse-muenchen/",
+        feedKey: "verbraucherzentrale",
+      }),
+    ];
+    const result = formatThreadReply(articles, feedPriorities, originalLinks);
+    // The URL must not appear at all - it's the same page as the original.
+    expect(result).not.toMatch(/stadtsparkasse-muenchen/);
+  });
+
+  it("treats utm-param URL as duplicate of clean URL in excludeLinks", () => {
+    const originalLinks = ["https://example.com/article"];
+    const articles = [
+      makeArticle({
+        id: "1",
+        title: "Same article",
+        link: "https://example.com/article?utm_source=rss&utm_medium=feed",
+        feedKey: "feed-a",
+      }),
+    ];
+    const result = formatThreadReply(articles, feedPriorities, originalLinks);
+    expect(result).not.toMatch(/example\.com\/article/);
+  });
+
+  it("treats fragment-only URL variation as duplicate in excludeLinks", () => {
+    const originalLinks = ["https://example.com/article"];
+    const articles = [
+      makeArticle({
+        id: "1",
+        title: "Same article",
+        link: "https://example.com/article#read-more",
+        feedKey: "feed-a",
+      }),
+    ];
+    const result = formatThreadReply(articles, feedPriorities, originalLinks);
+    expect(result).not.toMatch(/example\.com\/article/);
+  });
+
+  it("treats mixed-case-host URL as duplicate of lowercase URL in excludeLinks", () => {
+    const originalLinks = ["https://example.com/article"];
+    const articles = [
+      makeArticle({
+        id: "1",
+        title: "Same article",
+        link: "HTTPS://Example.COM/article",
+        feedKey: "feed-a",
+      }),
+    ];
+    const result = formatThreadReply(articles, feedPriorities, originalLinks);
+    expect(result).not.toMatch(/[Ee]xample\.[Cc][Oo][Mm]\/article/);
+  });
+
+  it("deduplicates cosmetic URL variants across multiple follow-up articles", () => {
+    // Multi-source cluster where two feeds emit the same page via
+    // slightly different URLs - the second copy must be filtered.
+    const articles = [
+      makeArticle({
+        id: "1",
+        title: "Article",
+        link: "https://shared.com/page",
+        feedKey: "feed-a",
+      }),
+      makeArticle({
+        id: "2",
+        title: "Article (other feed)",
+        link: "https://shared.com/page/?utm_source=twitter",
+        feedKey: "feed-b",
+      }),
+    ];
+    const result = formatThreadReply(articles, feedPriorities);
+    const linkMatches = result.match(/shared\.com\/page/g);
+    expect(linkMatches?.length).toBe(1);
+  });
 });

--- a/src/helper/clusterFormatter.ts
+++ b/src/helper/clusterFormatter.ts
@@ -1,6 +1,7 @@
 import rssFeedItem2Toot, { FeedItem } from "./rssFeedItem2Toot.js";
 import { ClusterArticle, isBreakingNews, pickPrimaryArticle } from "./similarity.js";
 import { getTopicEmoji } from "./engagementEnhancer.js";
+import { normalizeUrl } from "./normalizeUrl.js";
 
 const MASTODON_CHAR_LIMIT = 500;
 
@@ -115,38 +116,44 @@ export function formatThreadReply(
   const primary = pickPrimaryArticle(articles, feedPriorities);
   const title = primary.article.title || "";
   const link = primary.article.link || "";
+  const normalizedLink = normalizeUrl(link);
   const feedName = primary.feedKey || "unbekannt";
 
   const sourceCount = new Set(articles.map((a) => a.feedKey)).size;
   const prefix =
     sourceCount > 1 ? `Update (${sourceCount} Quellen): ` : "Update: ";
 
-  // Track links to exclude (from original toot) and links we've already added
-  const excludedLinksSet = new Set<string>(excludeLinks);
+  // Compare links in canonical form. Raw string equality lets cosmetic
+  // variants (trailing slash, utm params, fragment, host case) slip past
+  // the excludeLinks check, which is how the same verbraucherzentrale
+  // URL kept getting re-posted daily as a "new" follow-up. Display
+  // strings still use the original feed-supplied URL.
+  const excludedLinksSet = new Set<string>(
+    excludeLinks.map((l) => normalizeUrl(l)).filter((l) => l)
+  );
   const seenLinks = new Set<string>();
 
-  // Start building the toot - only add primary link if not in excluded set
   let toot: string;
-  if (excludedLinksSet.has(link)) {
-    // Primary link is already in quoted toot - use title only with source name
+  if (normalizedLink && excludedLinksSet.has(normalizedLink)) {
     toot = `${prefix}${title}\n\n(${feedName})`;
   } else {
     toot = `${prefix}${title}\n\n${feedName}: ${link}`;
-    seenLinks.add(link);
+    if (normalizedLink) seenLinks.add(normalizedLink);
   }
 
-  // Add other sources if multiple, deduplicating by link and excluding original toot links
   if (sourceCount > 1) {
     const otherSources = articles
       .filter((a) => a.id !== primary.id && a.feedKey !== primary.feedKey)
       .filter((a) => {
-        const l = a.article.link || "";
-        // Skip if already seen or in excluded links
-        if (seenLinks.has(l) || excludedLinksSet.has(l)) return false;
-        seenLinks.add(l);
+        const normalized = normalizeUrl(a.article.link);
+        if (!normalized) return false;
+        if (seenLinks.has(normalized) || excludedLinksSet.has(normalized)) {
+          return false;
+        }
+        seenLinks.add(normalized);
         return true;
       })
-      .slice(0, 2); // Limit to 2 additional sources
+      .slice(0, 2);
     for (const src of otherSources) {
       const srcLine = `\n${src.feedKey || "unbekannt"}: ${src.article.link || ""}`;
       if (toot.length + srcLine.length <= 500) {

--- a/src/helper/normalizeUrl.test.ts
+++ b/src/helper/normalizeUrl.test.ts
@@ -1,0 +1,123 @@
+import { describe, test, expect } from "@jest/globals";
+import { normalizeUrl } from "./normalizeUrl.js";
+
+// Why this helper exists:
+//
+// RSS feeds re-emit the same article with cosmetic URL variations -
+// trailing slashes, tracking params (utm_*, fbclid, gclid), fragments,
+// scheme/host case, duplicate query params. Raw string equality treats
+// each variant as a distinct URL. Downstream this leaks past the
+// `original_links` check in feed-tooter's follow-up path, so a story
+// the bot already posted about gets re-tooted as a "new follow-up"
+// every time the feed emits a cosmetic variant - which is the exact
+// behavior observed daily for the two verbraucherzentrale URLs.
+//
+// These tests pin down the canonicalization rules so both the storing
+// side (markStoryTooted) and the checking side (follow-up dedup) agree.
+
+describe("normalizeUrl", () => {
+  test("returns empty string for nullish / empty / whitespace input", () => {
+    expect(normalizeUrl(null)).toBe("");
+    expect(normalizeUrl(undefined)).toBe("");
+    expect(normalizeUrl("")).toBe("");
+    expect(normalizeUrl("   ")).toBe("");
+  });
+
+  test("collapses trailing slash on non-root path", () => {
+    // Same article re-emitted with/without trailing slash is the
+    // single most common variant we see from Wordpress-style feeds.
+    expect(normalizeUrl("https://example.com/a")).toBe(
+      normalizeUrl("https://example.com/a/")
+    );
+  });
+
+  test("keeps root slash (cannot strip from root path)", () => {
+    expect(normalizeUrl("https://example.com/")).toBe("https://example.com/");
+  });
+
+  test("lowercases scheme and host; preserves path case", () => {
+    // Hosts are case-insensitive per RFC 3986; paths are not (many CMSs
+    // rely on case-sensitive slugs). Only normalize what the spec allows.
+    expect(normalizeUrl("HTTPS://Example.COM/Path/To/Article")).toBe(
+      "https://example.com/Path/To/Article"
+    );
+  });
+
+  test("drops tracking params (utm_*, fbclid, gclid, mc_*, ref, share)", () => {
+    const clean = "https://example.com/a";
+    const tracked =
+      "https://example.com/a?utm_source=newsletter&utm_medium=email&fbclid=abc&gclid=xyz&mc_cid=1&ref=twitter&share=fb";
+    expect(normalizeUrl(tracked)).toBe(clean);
+  });
+
+  test("preserves non-tracking query params", () => {
+    // id, q, page, etc. are semantic - stripping them would mistake
+    // legitimately-different pages as duplicates.
+    expect(normalizeUrl("https://example.com/search?q=foo&page=2")).toBe(
+      "https://example.com/search?page=2&q=foo"
+    );
+  });
+
+  test("sorts query params for stable comparison", () => {
+    // Two URLs differing only in param order must normalize equal.
+    expect(normalizeUrl("https://example.com/a?b=2&a=1")).toBe(
+      normalizeUrl("https://example.com/a?a=1&b=2")
+    );
+  });
+
+  test("strips fragment", () => {
+    // The fragment is client-side only and never changes the document
+    // the feed is pointing at.
+    expect(normalizeUrl("https://example.com/a#section-2")).toBe(
+      "https://example.com/a"
+    );
+  });
+
+  test("drops default ports (80 for http, 443 for https)", () => {
+    expect(normalizeUrl("http://example.com:80/a")).toBe("http://example.com/a");
+    expect(normalizeUrl("https://example.com:443/a")).toBe(
+      "https://example.com/a"
+    );
+  });
+
+  test("keeps non-default ports", () => {
+    expect(normalizeUrl("https://example.com:8443/a")).toBe(
+      "https://example.com:8443/a"
+    );
+  });
+
+  test("is idempotent", () => {
+    const variants = [
+      "https://example.com/a/",
+      "HTTPS://Example.com/a?utm_source=x",
+      "https://example.com/a#top",
+      "https://example.com:443/a/",
+    ];
+    for (const v of variants) {
+      const once = normalizeUrl(v);
+      const twice = normalizeUrl(once);
+      expect(twice).toBe(once);
+    }
+  });
+
+  test("falls back to lowercased trimmed input for unparseable URLs", () => {
+    // Don't throw on garbage - dedup comparison still needs a key.
+    expect(normalizeUrl("  not a url  ")).toBe("not a url");
+    expect(normalizeUrl("javascript:alert(1)")).toBeTruthy(); // still returns something
+  });
+
+  test("the verbraucherzentrale URLs from the ongoing incident normalize to a single canonical form", () => {
+    // Real-world bug repro: these are the two URLs the bot kept
+    // re-tooting daily. Any of the common variants the feed might emit
+    // must collapse to the same key so the follow-up dedup catches them.
+    const variants = [
+      "https://www.verbraucherzentrale-saarland.de/verfahren/stadtsparkasse-muenchen",
+      "https://www.verbraucherzentrale-saarland.de/verfahren/stadtsparkasse-muenchen/",
+      "https://www.verbraucherzentrale-saarland.de/verfahren/stadtsparkasse-muenchen?utm_source=feed",
+      "https://www.verbraucherzentrale-saarland.de/verfahren/stadtsparkasse-muenchen#content",
+      "HTTPS://WWW.verbraucherzentrale-saarland.de/verfahren/stadtsparkasse-muenchen",
+    ];
+    const normalized = variants.map(normalizeUrl);
+    expect(new Set(normalized).size).toBe(1);
+  });
+});

--- a/src/helper/normalizeUrl.ts
+++ b/src/helper/normalizeUrl.ts
@@ -1,0 +1,74 @@
+// RSS feeds re-emit the same article with cosmetic URL variations -
+// trailing slashes, tracking params (utm_*, fbclid, gclid), fragments,
+// scheme/host case. Downstream, the follow-up dedup in feed-tooter
+// compares URLs as raw strings, so each variant is treated as a brand
+// new link and triggers another quote toot about content we already
+// posted. Normalizing on both the storing and checking side collapses
+// those variants to a single canonical form.
+
+const TRACKING_PARAMS = new Set([
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_term",
+  "utm_content",
+  "utm_name",
+  "utm_id",
+  "fbclid",
+  "gclid",
+  "gbraid",
+  "wbraid",
+  "msclkid",
+  "yclid",
+  "twclid",
+  "igshid",
+  "mc_cid",
+  "mc_eid",
+  "_ga",
+  "ref",
+  "ref_src",
+  "ref_url",
+  "share",
+  "source",
+]);
+
+export function normalizeUrl(input: string | null | undefined): string {
+  if (!input) return "";
+  const raw = input.trim();
+  if (!raw) return "";
+
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return raw.toLowerCase();
+  }
+
+  url.protocol = url.protocol.toLowerCase();
+  url.hostname = url.hostname.toLowerCase();
+  url.hash = "";
+
+  if (
+    (url.protocol === "http:" && url.port === "80") ||
+    (url.protocol === "https:" && url.port === "443")
+  ) {
+    url.port = "";
+  }
+
+  const kept: [string, string][] = [];
+  for (const [k, v] of url.searchParams) {
+    if (!TRACKING_PARAMS.has(k.toLowerCase())) {
+      kept.push([k, v]);
+    }
+  }
+  kept.sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  const rebuilt = new URLSearchParams();
+  for (const [k, v] of kept) rebuilt.append(k, v);
+  url.search = rebuilt.toString() ? `?${rebuilt.toString()}` : "";
+
+  if (url.pathname.length > 1 && url.pathname.endsWith("/")) {
+    url.pathname = url.pathname.replace(/\/+$/, "");
+  }
+
+  return url.toString();
+}

--- a/src/helper/storyLinks.test.ts
+++ b/src/helper/storyLinks.test.ts
@@ -1,0 +1,233 @@
+import { jest, describe, test, expect, beforeEach } from "@jest/globals";
+
+// Why this module exists:
+//
+// After the bot posts a follow-up quote toot for an already-tooted story,
+// the links included in that quote are NOT added to the story's
+// `original_links`. On the next day, if the feed re-emits one of those
+// same URLs (perhaps under a slightly different hash due to title/URL
+// cosmetic variation), the follow-up dedup check sees the link as "new"
+// and posts ANOTHER quote toot. This produces the daily re-tooting the
+// user is observing.
+//
+// `extendStoryOriginalLinks` closes that loop: after a successful
+// follow-up post, the caller appends the newly-posted (normalized) links
+// to the story's `original_links` so tomorrow's follow-up dedup treats
+// them as already-seen.
+
+type Call = {
+  seq: number;
+  table: string;
+  op: "select" | "update";
+  args: any[];
+  filters: { method: string; col: string; value: any }[];
+};
+
+let calls: Call[];
+let seq: number;
+let selectResult: { data: any; error: any };
+let updateResult: { error: any };
+
+const resolvable = (v: any) => Promise.resolve(v);
+
+function makeSelectChain(call: Call, table: string) {
+  const chain: any = {
+    eq: (col: string, val: any) => {
+      call.filters.push({ method: "eq", col, value: val });
+      return chain;
+    },
+    maybeSingle: () =>
+      resolvable(selectResult ?? { data: null, error: null }),
+    single: () => resolvable(selectResult ?? { data: null, error: null }),
+    then: (resolve: any, reject: any) =>
+      resolvable(selectResult ?? { data: [], error: null }).then(resolve, reject),
+  };
+  return chain;
+}
+
+function makeUpdateChain(call: Call) {
+  const chain: any = {
+    eq: (col: string, val: any) => {
+      call.filters.push({ method: "eq", col, value: val });
+      return resolvable(updateResult);
+    },
+  };
+  return chain;
+}
+
+function record(op: Call["op"], table: string, args: any[]): Call {
+  const call: Call = { seq: seq++, table, op, args, filters: [] };
+  calls.push(call);
+  return call;
+}
+
+function makeFrom(table: string) {
+  return {
+    select: (...args: any[]) => {
+      const call = record("select", table, args);
+      return makeSelectChain(call, table);
+    },
+    update: (...args: any[]) => {
+      const call = record("update", table, args);
+      return makeUpdateChain(call);
+    },
+  };
+}
+
+const mockFrom = jest.fn((table: string) => makeFrom(table));
+const fakeClient: any = { from: mockFrom };
+
+const { extendStoryOriginalLinks } = await import("./storyLinks.js");
+
+beforeEach(() => {
+  calls = [];
+  seq = 0;
+  selectResult = { data: null, error: null };
+  updateResult = { error: null };
+  mockFrom.mockClear();
+  jest.spyOn(console, "error").mockImplementation(() => {});
+});
+
+describe("extendStoryOriginalLinks", () => {
+  test("adds normalized new links to an existing story's original_links", async () => {
+    selectResult = {
+      data: {
+        original_links: [
+          "https://www.verbraucherzentrale-saarland.de/verfahren/stadtsparkasse-muenchen",
+        ],
+      },
+      error: null,
+    };
+
+    await extendStoryOriginalLinks(fakeClient, "story-1", [
+      "https://example.com/new-source",
+    ]);
+
+    const updateCall = calls.find((c) => c.op === "update");
+    expect(updateCall).toBeDefined();
+    const payload = updateCall!.args[0];
+    expect(payload.original_links).toEqual(
+      expect.arrayContaining([
+        "https://www.verbraucherzentrale-saarland.de/verfahren/stadtsparkasse-muenchen",
+        "https://example.com/new-source",
+      ])
+    );
+  });
+
+  test("does NOT write when all new links are already present (normalized)", async () => {
+    // The core regression guard: if the follow-up just re-posted
+    // cosmetic variants of existing links, the update would be a no-op.
+    // We skip the write entirely to save a DB round-trip - AND so the
+    // test confirms we correctly detected the dedup.
+    selectResult = {
+      data: {
+        original_links: ["https://example.com/a"],
+      },
+      error: null,
+    };
+
+    await extendStoryOriginalLinks(fakeClient, "story-1", [
+      "https://example.com/a/?utm_source=feed", // same URL, normalized equivalent
+      "HTTPS://Example.COM/a#top", // same URL, mixed case + fragment
+    ]);
+
+    expect(calls.find((c) => c.op === "update")).toBeUndefined();
+  });
+
+  test("normalizes both existing and incoming links before deduping", async () => {
+    // Older stories may have un-normalized URLs in original_links from
+    // before normalization shipped. We must normalize on read too, so
+    // legacy data doesn't defeat the dedup.
+    selectResult = {
+      data: {
+        original_links: ["https://example.com/a/?utm_source=old"],
+      },
+      error: null,
+    };
+
+    await extendStoryOriginalLinks(fakeClient, "story-1", [
+      "https://example.com/a", // equivalent to the legacy entry
+      "https://example.com/b", // genuinely new
+    ]);
+
+    const updateCall = calls.find((c) => c.op === "update");
+    expect(updateCall).toBeDefined();
+    const payload = updateCall!.args[0];
+    // Must contain exactly two canonical URLs, no dupes.
+    expect(payload.original_links).toHaveLength(2);
+    expect(new Set(payload.original_links)).toEqual(
+      new Set(["https://example.com/a", "https://example.com/b"])
+    );
+  });
+
+  test("handles story with null/undefined original_links (legacy rows)", async () => {
+    selectResult = {
+      data: { original_links: null },
+      error: null,
+    };
+
+    await extendStoryOriginalLinks(fakeClient, "story-1", [
+      "https://example.com/a",
+    ]);
+
+    const updateCall = calls.find((c) => c.op === "update");
+    expect(updateCall).toBeDefined();
+    expect(updateCall!.args[0].original_links).toEqual([
+      "https://example.com/a",
+    ]);
+  });
+
+  test("no-op for empty newLinks", async () => {
+    await extendStoryOriginalLinks(fakeClient, "story-1", []);
+    expect(calls).toHaveLength(0);
+  });
+
+  test("filters out empty/whitespace links from the input", async () => {
+    selectResult = {
+      data: { original_links: [] },
+      error: null,
+    };
+
+    await extendStoryOriginalLinks(fakeClient, "story-1", [
+      "",
+      "   ",
+      "https://example.com/a",
+    ]);
+
+    const updateCall = calls.find((c) => c.op === "update");
+    expect(updateCall).toBeDefined();
+    expect(updateCall!.args[0].original_links).toEqual([
+      "https://example.com/a",
+    ]);
+  });
+
+  test("select failure: logs and skips write - does not corrupt data", async () => {
+    selectResult = {
+      data: null,
+      error: { message: "select kaput" },
+    };
+
+    await extendStoryOriginalLinks(fakeClient, "story-1", [
+      "https://example.com/a",
+    ]);
+
+    expect(calls.find((c) => c.op === "update")).toBeUndefined();
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  test("update failure: logs but does not throw (tooter must not crash)", async () => {
+    selectResult = {
+      data: { original_links: [] },
+      error: null,
+    };
+    updateResult = { error: { message: "update kaput" } };
+
+    await expect(
+      extendStoryOriginalLinks(fakeClient, "story-1", [
+        "https://example.com/a",
+      ])
+    ).resolves.toBeUndefined();
+
+    expect(console.error).toHaveBeenCalled();
+  });
+});

--- a/src/helper/storyLinks.ts
+++ b/src/helper/storyLinks.ts
@@ -1,0 +1,58 @@
+import type createClientType from "./db.js";
+import { normalizeUrl } from "./normalizeUrl.js";
+
+// After a follow-up quote-toot is posted for an already-tooted story,
+// we need to record the newly-posted links so the next day's follow-up
+// dedup treats them as already-seen. Without this, every time the RSS
+// feed re-emits the same article (with a fresh hash, e.g. because the
+// title changed cosmetically), the tooter re-posts a quote toot about
+// it - which is the daily re-tooting observed for the verbraucherzentrale
+// URLs.
+//
+// Normalization is applied on BOTH sides (existing + incoming) so:
+//   - cosmetic URL variants collapse to one canonical entry
+//   - legacy rows with un-normalized URLs still dedup correctly
+export async function extendStoryOriginalLinks(
+  db: ReturnType<typeof createClientType>,
+  storyId: string,
+  newLinks: string[]
+): Promise<void> {
+  const incoming = newLinks
+    .map((l) => normalizeUrl(l))
+    .filter((l): l is string => !!l);
+
+  if (incoming.length === 0) return;
+
+  const { data, error: selectError } = await db
+    .from("stories")
+    .select("original_links")
+    .eq("id", storyId)
+    .single();
+
+  if (selectError) {
+    console.error(
+      `[extendStoryOriginalLinks] Select failed for story ${storyId}: ${selectError.message}`
+    );
+    return;
+  }
+
+  const existing = ((data?.original_links ?? []) as string[])
+    .map((l) => normalizeUrl(l))
+    .filter((l): l is string => !!l);
+
+  const merged = new Set<string>(existing);
+  const before = merged.size;
+  for (const link of incoming) merged.add(link);
+  if (merged.size === before) return;
+
+  const { error: updateError } = await db
+    .from("stories")
+    .update({ original_links: Array.from(merged) })
+    .eq("id", storyId);
+
+  if (updateError) {
+    console.error(
+      `[extendStoryOriginalLinks] Update failed for story ${storyId}: ${updateError.message}`
+    );
+  }
+}

--- a/src/helper/storyMatcher.ts
+++ b/src/helper/storyMatcher.ts
@@ -4,6 +4,7 @@ import {
   batchSemanticSimilarity,
   SemanticPair,
 } from "./semanticSimilarity.js";
+import { normalizeUrl } from "./normalizeUrl.js";
 
 import { createRequire } from "node:module";
 const require = createRequire(import.meta.url);
@@ -321,7 +322,9 @@ export async function processNewArticles(
 
 /**
  * Mark a story as tooted and store the toot ID and original links.
- * Original links are stored to prevent duplicate links in quote replies.
+ * Original links are stored in normalized form so cosmetic URL variants
+ * (trailing slash, utm params, fragment) don't defeat the follow-up
+ * dedup on the next tooter tick.
  */
 export async function markStoryTooted(
   storyId: string,
@@ -330,12 +333,20 @@ export async function markStoryTooted(
 ): Promise<void> {
   const db = createClient();
 
+  const normalized = Array.from(
+    new Set(
+      originalLinks
+        .map((l) => normalizeUrl(l))
+        .filter((l): l is string => !!l)
+    )
+  );
+
   const { error } = await db
     .from("stories")
     .update({
       tooted: true,
       toot_id: tootId,
-      original_links: originalLinks,
+      original_links: normalized,
     })
     .eq("id", storyId);
 

--- a/src/jobs/feed-tooter.ts
+++ b/src/jobs/feed-tooter.ts
@@ -24,6 +24,8 @@ import {
   recordPinnedToot,
 } from "../helper/botState.js";
 import { saveHashesAndFinalize } from "../helper/hashPersistence.js";
+import { normalizeUrl } from "../helper/normalizeUrl.js";
+import { extendStoryOriginalLinks } from "../helper/storyLinks.js";
 
 import { createRequire } from "node:module";
 const require = createRequire(import.meta.url);
@@ -465,10 +467,15 @@ type StoryInfo = {
         score: scoreFeedItem(row.data._feedKey, row.pub_date, FEED_PRIORITIES, MIN_FRESHNESS_HOURS),
       }));
 
-      // Check if any articles have new links (not in original toot)
-      const originalLinksSet = new Set(storyInfo.original_links || []);
+      // Compare in normalized form on BOTH sides. Legacy stories written
+      // before normalization shipped may have raw URLs in original_links;
+      // normalizing on read lets the dedup catch them too.
+      const normalizedOriginalLinks = (storyInfo.original_links || [])
+        .map((l) => normalizeUrl(l))
+        .filter((l): l is string => !!l);
+      const originalLinksSet = new Set(normalizedOriginalLinks);
       const newLinks = articles
-        .map((a) => a.article.link)
+        .map((a) => normalizeUrl(a.article.link))
         .filter((link): link is string => !!link && !originalLinksSet.has(link));
 
       if (newLinks.length === 0) {
@@ -484,7 +491,7 @@ type StoryInfo = {
       const replyText = formatThreadReply(
         articles,
         FEED_PRIORITIES,
-        storyInfo.original_links || []
+        normalizedOriginalLinks
       );
 
       // Use quotedStatusId instead of inReplyToId for better visibility
@@ -495,6 +502,16 @@ type StoryInfo = {
         visibility: "public",
         language: "de",
       });
+
+      // Append the just-posted links to the story's original_links so the
+      // next tooter tick treats them as already-seen. Without this, the
+      // same URL can be re-ingested (new hash from a cosmetic title change)
+      // and re-posted as a "new" follow-up tomorrow.
+      await extendStoryOriginalLinks(
+        db,
+        storyId,
+        articles.map((a) => a.article.link || "")
+      );
 
       const articleIds = articles.map((a) => a.id);
       await saveHashesAndFinalize(db, articleIds, "thread-reply");


### PR DESCRIPTION
## Why PR #7 didn't stop the daily re-toots

PR #7 fixed dedup leaks in the **cleanup paths** (upsert-before-delete), but the verbraucherzentrale URLs kept re-tooting anyway. Code audit found two more bugs on the **follow-up quote-toot path**:

### Bug 1 — follow-up dedup compared URLs as raw strings
`feed-tooter.ts` and `clusterFormatter.formatThreadReply` built `excludedLinksSet` from `story.original_links` with `new Set(links)` — byte-exact comparison. Every cosmetic variant the RSS feed emits (trailing slash, `?utm_*`, `#fragment`, host case) slipped past the check, so a quote toot was posted for what was effectively the same URL.

### Bug 2 — `original_links` was never appended after a follow-up
`markStoryTooted` seeded `original_links` on the initial toot, but after a follow-up quote-toot posted, the new URLs were never written back. Even if Bug 1 were fixed, a genuinely-new URL posted today would not be in the set tomorrow, so the same follow-up kept firing.

## Fix

- New `src/helper/normalizeUrl.ts` — canonicalize scheme/host case, strip tracking params (`utm_*`, `fbclid`, `gclid`, …), strip fragment, drop default ports, collapse trailing slash. Applied on **both** store side (`markStoryTooted`) and compare side (`feed-tooter.ts`, `formatThreadReply`). Display strings still use the original feed-supplied URL.
- New `src/helper/storyLinks.ts` — `extendStoryOriginalLinks(db, storyId, newLinks)` appends normalized links to `stories.original_links` after a successful follow-up post. Also normalizes the existing array on read so legacy rows dedup correctly.
- `feed-tooter.ts` calls `extendStoryOriginalLinks` after each successful quote-toot.

## TDD

Tests written first (RED), then implementation (GREEN):

- 5 new regression tests in `clusterFormatter.test.ts` — trailing-slash, utm, fragment, mixed-case-host, cross-source cosmetic variants.
- 12 tests in `normalizeUrl.test.ts` with real verbraucherzentrale URL variants.
- 7 tests in `storyLinks.test.ts` — append, no-op when already present (via normalization), legacy-row normalization, empty/null handling, error paths.

Before implementation the 5 clusterFormatter tests failed and the 2 new test files failed to load (correct RED). After implementation: **360/360 tests pass, typecheck clean**.

## Caveat

No Supabase access in the sandbox, so this is a code-level fix matched to the symptom pattern. If the verbraucherzentrale re-toots continue after merge, the remaining suspect is an older story row whose `original_links` never captured the URL at all — `extendStoryOriginalLinks` repairs that on the next follow-up tick.

https://claude.ai/code/session_01Nmo6zZmsLeXPZ1EBjBnZRa