### PR TITLE
fix: match re-ingested articles to their story by URL regardless of age

### DIFF
--- a/src/helper/findStoryByUrl.test.ts
+++ b/src/helper/findStoryByUrl.test.ts
@@ -1,0 +1,294 @@
+import { jest, describe, test, expect, beforeEach } from "@jest/globals";
+
+// Why this module exists:
+//
+// `findMatchingStory` (in storyMatcher.ts) only searches stories updated in
+// the last 72h. When the verbraucherzentrale feed re-emits a long-lived
+// article weeks later with a cosmetic title/URL variation, the grabber's
+// hash-based dedup fails (hash shifts), the article is re-ingested, and
+// `findMatchingStory` fails to find the older story. A NEW story is created
+// and fully re-tooted. That's the daily re-toot still observed after PR #9.
+//
+// `findStoryByUrl` is a URL-based short-circuit that ignores the 72h window:
+// if the article's normalized link is already in some story's
+// `original_links`, that's the matching story — regardless of age, token
+// drift, or cosmetic variation in the URL.
+
+type Call = {
+  seq: number;
+  table: string;
+  op: "select";
+  args: any[];
+  filters: { method: string; col: string; value: any }[];
+  limit?: number;
+};
+
+let calls: Call[];
+let seq: number;
+let selectResult: { data: any; error: any };
+
+const resolvable = (v: any) => Promise.resolve(v);
+
+function makeSelectChain(call: Call) {
+  const chain: any = {
+    not: (col: string, op: string, val: any) => {
+      call.filters.push({ method: `not.${op}`, col, value: val });
+      return chain;
+    },
+    order: (col: string, opts: any) => {
+      call.filters.push({ method: "order", col, value: opts });
+      return chain;
+    },
+    limit: (n: number) => {
+      call.limit = n;
+      return chain;
+    },
+    then: (resolve: any, reject: any) =>
+      resolvable(selectResult ?? { data: [], error: null }).then(resolve, reject),
+  };
+  return chain;
+}
+
+function record(op: Call["op"], table: string, args: any[]): Call {
+  const call: Call = { seq: seq++, table, op, args, filters: [] };
+  calls.push(call);
+  return call;
+}
+
+function makeFrom(table: string) {
+  return {
+    select: (...args: any[]) => {
+      const call = record("select", table, args);
+      return makeSelectChain(call);
+    },
+  };
+}
+
+const mockFrom = jest.fn((table: string) => makeFrom(table));
+const fakeClient: any = { from: mockFrom };
+
+const { findStoryByUrl } = await import("./findStoryByUrl.js");
+
+beforeEach(() => {
+  calls = [];
+  seq = 0;
+  selectResult = { data: [], error: null };
+  mockFrom.mockClear();
+  jest.spyOn(console, "error").mockImplementation(() => {});
+});
+
+describe("findStoryByUrl", () => {
+  test("returns null for empty/nullish links (no query issued)", async () => {
+    const a = await findStoryByUrl(fakeClient, "");
+    const b = await findStoryByUrl(fakeClient, null as any);
+    const c = await findStoryByUrl(fakeClient, undefined as any);
+
+    expect(a).toBeNull();
+    expect(b).toBeNull();
+    expect(c).toBeNull();
+    expect(calls).toHaveLength(0);
+  });
+
+  test("returns null when no stories have original_links", async () => {
+    selectResult = { data: [], error: null };
+
+    const result = await findStoryByUrl(
+      fakeClient,
+      "https://www.verbraucherzentrale-saarland.de/verfahren/stadtsparkasse-muenchen"
+    );
+
+    expect(result).toBeNull();
+    expect(calls).toHaveLength(1);
+    expect(calls[0].table).toBe("stories");
+  });
+
+  test("returns matching story when normalized URL is in a story's original_links", async () => {
+    const story = {
+      id: "story-old",
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-02T00:00:00Z", // >72h old from today
+      tooted: true,
+      toot_id: "toot-123",
+      original_links: [
+        "https://www.verbraucherzentrale-saarland.de/verfahren/stadtsparkasse-muenchen",
+      ],
+      primary_title: "Klage gegen Stadtsparkasse München",
+      tokens: ["klage", "stadtsparkasse"],
+      article_count: 3,
+    };
+    selectResult = { data: [story], error: null };
+
+    const result = await findStoryByUrl(
+      fakeClient,
+      "https://www.verbraucherzentrale-saarland.de/verfahren/stadtsparkasse-muenchen"
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe("story-old");
+  });
+
+  test("matches despite cosmetic URL drift in the incoming link", async () => {
+    // The whole point: the feed re-emits the same article with utm params,
+    // trailing slash, or fragment. The normalized form still matches.
+    const story = {
+      id: "story-1",
+      original_links: [
+        "https://www.verbraucherzentrale-saarland.de/verfahren/stadtsparkasse-muenchen",
+      ],
+      primary_title: "X",
+      tokens: [],
+      article_count: 1,
+      tooted: true,
+      toot_id: "t",
+      created_at: "2026-01-01",
+      updated_at: "2026-01-01",
+    };
+    selectResult = { data: [story], error: null };
+
+    const result = await findStoryByUrl(
+      fakeClient,
+      "https://www.verbraucherzentrale-saarland.de/verfahren/stadtsparkasse-muenchen/?utm_source=newsletter#anchor"
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe("story-1");
+  });
+
+  test("matches legacy stories whose original_links were stored un-normalized", async () => {
+    // Stories tooted before normalization shipped may contain raw URLs.
+    // We must normalize both sides (store + lookup) so the dedup still
+    // catches them.
+    const story = {
+      id: "legacy-story",
+      original_links: [
+        "HTTPS://www.Verbraucherzentrale-Saarland.de/verfahren/stadtsparkasse-muenchen/?utm_source=rss#top",
+      ],
+      primary_title: "X",
+      tokens: [],
+      article_count: 1,
+      tooted: true,
+      toot_id: "t",
+      created_at: "2026-01-01",
+      updated_at: "2026-01-01",
+    };
+    selectResult = { data: [story], error: null };
+
+    const result = await findStoryByUrl(
+      fakeClient,
+      "https://www.verbraucherzentrale-saarland.de/verfahren/stadtsparkasse-muenchen"
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe("legacy-story");
+  });
+
+  test("returns null when no story contains the URL", async () => {
+    selectResult = {
+      data: [
+        {
+          id: "other",
+          original_links: ["https://example.com/unrelated"],
+          primary_title: "X",
+          tokens: [],
+          article_count: 1,
+          tooted: true,
+          toot_id: "t",
+          created_at: "2026-01-01",
+          updated_at: "2026-01-01",
+        },
+      ],
+      error: null,
+    };
+
+    const result = await findStoryByUrl(
+      fakeClient,
+      "https://www.verbraucherzentrale-saarland.de/verfahren/stadtsparkasse-muenchen"
+    );
+
+    expect(result).toBeNull();
+  });
+
+  test("returns first match when multiple stories contain the URL (newest wins by order)", async () => {
+    // We order by updated_at DESC, so the most recently updated story wins.
+    // This matters if a content migration or bug ever produced dupes -
+    // we pick the most recent as the canonical one.
+    selectResult = {
+      data: [
+        {
+          id: "newer",
+          original_links: ["https://example.com/a"],
+          primary_title: "X",
+          tokens: [],
+          article_count: 1,
+          tooted: true,
+          toot_id: "t",
+          created_at: "2026-01-01",
+          updated_at: "2026-03-01",
+        },
+        {
+          id: "older",
+          original_links: ["https://example.com/a"],
+          primary_title: "X",
+          tokens: [],
+          article_count: 1,
+          tooted: true,
+          toot_id: "t",
+          created_at: "2026-01-01",
+          updated_at: "2026-01-05",
+        },
+      ],
+      error: null,
+    };
+
+    const result = await findStoryByUrl(fakeClient, "https://example.com/a/");
+
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe("newer");
+  });
+
+  test("select failure: returns null and logs", async () => {
+    selectResult = { data: null, error: { message: "db dead" } };
+
+    const result = await findStoryByUrl(
+      fakeClient,
+      "https://example.com/a"
+    );
+
+    expect(result).toBeNull();
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  test("skips stories with null/empty original_links without crashing", async () => {
+    selectResult = {
+      data: [
+        {
+          id: "empty",
+          original_links: null,
+          primary_title: "X",
+          tokens: [],
+          article_count: 1,
+          tooted: true,
+          toot_id: "t",
+          created_at: "2026-01-01",
+          updated_at: "2026-01-01",
+        },
+        {
+          id: "match",
+          original_links: ["https://example.com/a"],
+          primary_title: "X",
+          tokens: [],
+          article_count: 1,
+          tooted: true,
+          toot_id: "t",
+          created_at: "2026-01-01",
+          updated_at: "2026-01-01",
+        },
+      ],
+      error: null,
+    };
+
+    const result = await findStoryByUrl(fakeClient, "https://example.com/a");
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe("match");
+  });
+});

--- a/src/helper/findStoryByUrl.ts
+++ b/src/helper/findStoryByUrl.ts
@@ -1,0 +1,50 @@
+import type createClientType from "./db.js";
+import { normalizeUrl } from "./normalizeUrl.js";
+import type { StoryRecord } from "./storyMatcher.js";
+
+// URL-based short-circuit for findMatchingStory.
+//
+// The time-windowed token match in findMatchingStory (72h) misses stories
+// that were tooted weeks ago when the RSS feed re-emits the same article
+// with a cosmetic hash drift. That re-ingestion path produces a brand-new
+// story and a fresh full toot - the daily re-toot the user keeps seeing.
+//
+// This helper scans recent stories' original_links (normalized on BOTH
+// sides so legacy un-normalized entries still match) and returns the
+// matching story regardless of age, token drift, or cosmetic URL variation
+// in the incoming link. Ordered newest-first so a recent row beats an
+// older duplicate if one ever exists.
+const STORY_SCAN_LIMIT = 500;
+
+export async function findStoryByUrl(
+  db: ReturnType<typeof createClientType>,
+  link: string | null | undefined
+): Promise<StoryRecord | null> {
+  const normalized = normalizeUrl(link ?? "");
+  if (!normalized) return null;
+
+  const { data, error } = await db
+    .from("stories")
+    .select("*")
+    .not("original_links", "is", null)
+    .order("updated_at", { ascending: false })
+    .limit(STORY_SCAN_LIMIT);
+
+  if (error) {
+    console.error(`[findStoryByUrl] select failed: ${error.message}`);
+    return null;
+  }
+
+  if (!data || data.length === 0) return null;
+
+  for (const story of data as StoryRecord[]) {
+    const links = story.original_links ?? [];
+    for (const raw of links) {
+      if (normalizeUrl(raw) === normalized) {
+        return story;
+      }
+    }
+  }
+
+  return null;
+}

--- a/src/helper/storyMatcher.ts
+++ b/src/helper/storyMatcher.ts
@@ -5,6 +5,7 @@ import {
   SemanticPair,
 } from "./semanticSimilarity.js";
 import { normalizeUrl } from "./normalizeUrl.js";
+import { findStoryByUrl } from "./findStoryByUrl.js";
 
 import { createRequire } from "node:module";
 const require = createRequire(import.meta.url);
@@ -28,6 +29,7 @@ export interface ArticleForMatching {
   contentSnippet?: string;
   pubDate: string;
   feedKey?: string;
+  link?: string;
 }
 
 // Configurable thresholds from settings
@@ -51,6 +53,21 @@ export async function findMatchingStory(
   dbTable: string
 ): Promise<StoryRecord | null> {
   const db = createClient();
+
+  // URL-based short-circuit: if this article's link is already in some
+  // story's original_links, that's the matching story - regardless of
+  // the story's age or the article's tokens. Catches re-ingested feed
+  // items whose hash drifted cosmetically and whose story is >72h old
+  // (outside the token-match window below).
+  if (article.link) {
+    const byUrl = await findStoryByUrl(db, article.link);
+    if (byUrl) {
+      console.log(
+        `Article "${article.title.slice(0, 50)}..." matches story "${byUrl.primary_title.slice(0, 50)}..." (url match)`
+      );
+      return byUrl;
+    }
+  }
 
   const cutoff = new Date();
   cutoff.setHours(cutoff.getHours() - STORY_MAX_AGE_HOURS);

--- a/src/jobs/feed-grabber.ts
+++ b/src/jobs/feed-grabber.ts
@@ -179,6 +179,7 @@ async function fetchFeedBatch(
         contentSnippet: row.data.contentSnippet,
         pubDate: row.pub_date,
         feedKey: row.data._feedKey,
+        link: row.data.link,
       })
     );
     await processNewArticles(articlesForMatching, settings.db_table);


### PR DESCRIPTION
## Why PR #9 didn't fully stop the re-toots

PR #9 fixed the **follow-up** quote-toot path (normalized URL comparison + `extendStoryOriginalLinks`). That's correct, but the user still observed the bot tooting the verbraucherzentrale Stadtsparkasse article. Log confirmed the re-ingestion path:

```
Article "Klage gegen Stadtsparkasse München..." matches story "Klage gegen Stadtsparkasse München..." (token score=1.000)
→ Added to existing story: "Klage gegen Stadtsparkasse München..."
```

Token score 1.000 on an already-existing story means the feed re-emitted **the same article** with a cosmetic title/link drift (enough to produce a new hash, so grabber's dedup fails).

## The missing piece

`findMatchingStory` only queries stories updated in the last 72 hours (`story_max_age_hours`). Long-lived feed items (`/verfahren/stadtsparkasse-muenchen`, `/wissen/.../postidentanfragen-...`) get re-emitted weeks after their initial toot. By then, the matching story is outside the 72h window, `findMatchingStory` returns null, a **new** story is created, and the tooter posts it as a fresh initial toot — full re-toot.

## Fix

New `findStoryByUrl(db, link)` helper: scans recent stories' `original_links` (normalized on **both** sides so legacy un-normalized entries still match) and returns the story regardless of age, token drift, or cosmetic URL variation in the incoming link.

`findMatchingStory` checks URL first; if found, returns immediately. Otherwise falls through to the existing 72h token/semantic match. `ArticleForMatching` grows a `link?` field; `feed-grabber` wires `row.data.link` through.

End-to-end after this fix:
1. Feed re-emits article with cosmetic drift → hash dedup misses → article inserted.
2. `findMatchingStory` → `findStoryByUrl` → finds the old story by URL → returns it.
3. Article is attached to the existing story (no new story created).
4. Tooter's follow-up path (PR #9) sees the URL already in `original_links` → skips quote, saves hash.
5. No re-toot.

## TDD

9 new tests, all failed before implementation (module didn't exist → RED), pass now:
- null/empty input short-circuits without querying
- exact URL match on any-age story
- cosmetic URL drift in incoming link (utm, fragment, trailing slash, case)
- legacy un-normalized URL in `original_links` still matches
- no-match returns null (falls through)
- newest-wins ordering
- select failure returns null + logs
- null `original_links` entries skipped

**369/369 tests pass, typecheck clean.**

## Caveat

This catches re-ingested articles by URL but doesn't prevent the re-ingestion itself. Hash dedup still drifts with cosmetic title/link changes, so a wasted DB row is inserted + upserted on each re-emission. Fixing that would mean normalizing the link in the hash computation (`feed-grabber.ts:59`), which invalidates every existing `tooted_hashes` row for one day. Worth considering as a separate, opt-in follow-up if the noisy inserts become visible; not urgent since the user-visible symptom (re-toot) is now addressed.

https://claude.ai/code/session_01Nmo6zZmsLeXPZ1EBjBnZRa