### PR TITLE
fix: always post digest even with no external engagement

### DIFF
--- a/src/jobs/daily-digest.ts
+++ b/src/jobs/daily-digest.ts
@@ -59,14 +59,12 @@ function getDateBerlin(date: string): string {
     const context = await mastoClient.v1.statuses.$select(status.id).context.fetch();
     const engagement = calculateEngagement(status, context.descendants, me.id);
 
-    if (engagement.totalInteractions > 0) {
-      scored.push({ status, activity: engagement.totalInteractions });
+    scored.push({ status, activity: engagement.totalInteractions });
 
-      if (engagement.ownReplies > 0) {
-        console.log(
-          `[daily-digest] Status ${status.id}: excluded ${engagement.ownReplies} own replies`
-        );
-      }
+    if (engagement.ownReplies > 0) {
+      console.log(
+        `[daily-digest] Status ${status.id}: excluded ${engagement.ownReplies} own replies`
+      );
     }
   }
 
@@ -75,7 +73,7 @@ function getDateBerlin(date: string): string {
   const topScored = scored.slice(0, 5);
 
   if (topScored.length === 0) {
-    console.log("[daily-digest] No statuses with external interactions, skipping digest.");
+    console.log("[daily-digest] No statuses to include in digest, skipping.");
     if (parentPort) parentPort.postMessage("done");
     else process.exit(0);
     return;

--- a/src/jobs/weekly-digest.ts
+++ b/src/jobs/weekly-digest.ts
@@ -62,14 +62,12 @@ function getSevenDaysAgoBerlin(): string {
     const context = await mastoClient.v1.statuses.$select(status.id).context.fetch();
     const engagement = calculateEngagement(status, context.descendants, me.id);
 
-    if (engagement.totalInteractions > 0) {
-      scored.push({ status, activity: engagement.totalInteractions });
+    scored.push({ status, activity: engagement.totalInteractions });
 
-      if (engagement.ownReplies > 0) {
-        console.log(
-          `[weekly-digest] Status ${status.id}: excluded ${engagement.ownReplies} own replies`
-        );
-      }
+    if (engagement.ownReplies > 0) {
+      console.log(
+        `[weekly-digest] Status ${status.id}: excluded ${engagement.ownReplies} own replies`
+      );
     }
   }
 
@@ -78,7 +76,7 @@ function getSevenDaysAgoBerlin(): string {
   const topScored = scored.slice(0, 5);
 
   if (topScored.length === 0) {
-    console.log("[weekly-digest] No statuses with external interactions, skipping digest.");
+    console.log("[weekly-digest] No statuses to include in digest, skipping.");
     if (parentPort) parentPort.postMessage("done");
     else process.exit(0);
     return;


### PR DESCRIPTION
## Summary

- `4ee13c4` correctly excluded bot's own Update replies from engagement scores, but left a `totalInteractions > 0` guard that silently dropped every post with zero *external* engagement
- For a small bot this caused the daily/weekly digest to always exit early and never post
- Removes the guard so all of today's/this week's statuses are ranked by external engagement and the top 5 are always included

## Test plan

- [x] Run `npm test` — all 398 tests pass
- [x] Trigger `npm run daily-digest` manually and confirm a toot is posted even when no posts have external interactions

🤖 Generated with [Claude Code](https://claude.com/claude-code)