### PR TITLE
feat: emoji-enhanced story threading context

### DIFF
--- a/src/helper/clusterFormatter.test.ts
+++ b/src/helper/clusterFormatter.test.ts
@@ -195,7 +195,7 @@ describe("formatThreadReply", () => {
       }),
     ];
     const result = formatThreadReply(articles, feedPriorities);
-    expect(result).toContain("Update: Update on breaking story");
+    expect(result).toContain("🔗 Update: Update on breaking story");
     expect(result).toContain("feed-a: https://a.com/update");
   });
 
@@ -215,7 +215,7 @@ describe("formatThreadReply", () => {
       }),
     ];
     const result = formatThreadReply(articles, feedPriorities);
-    expect(result).toContain("Update (2 Quellen):");
+    expect(result).toContain("🔗 Update (📍2 Quellen):");
     expect(result).toContain("feed-a: https://a.com/1");
     expect(result).toContain("feed-b: https://b.com/2");
   });
@@ -236,7 +236,7 @@ describe("formatThreadReply", () => {
     const result = formatThreadReply(articles, feedPriorities, originalLinks);
     // Should NOT include the link since it's already in the quoted toot
     expect(result).not.toContain("https://a.com/original");
-    expect(result).toContain("Update: Same story different angle");
+    expect(result).toContain("🔗 Update: Same story different angle");
     expect(result).toContain("(feed-a)"); // Source name only, no link
   });
 

--- a/src/helper/clusterFormatter.ts
+++ b/src/helper/clusterFormatter.ts
@@ -128,7 +128,7 @@ export function formatThreadReply(
 
   const sourceCount = new Set(articles.map((a) => a.feedKey)).size;
   const prefix =
-    sourceCount > 1 ? `Update (${sourceCount} Quellen): ` : "Update: ";
+    sourceCount > 1 ? `🔗 Update (📍${sourceCount} Quellen): ` : "🔗 Update: ";
 
   // Compare links in canonical form. Raw string equality lets cosmetic
   // variants (trailing slash, utm params, fragment, host case) slip past


### PR DESCRIPTION
## Summary

- Thread replies now start with `🔗 Update:` (single source) or `🔗 Update (📍N Quellen):` (multi-source)
- Makes thread continuations immediately recognizable in Mastodon timelines
- All existing tests updated; 398 tests passing

Closes #45

## Test plan

- [x] All 398 Jest tests pass
- [x] `clusterFormatter` tests updated to match new prefix format

🤖 Generated with [Claude Code](https://claude.com/claude-code)