### PR TITLE
docs: refresh CLAUDE.md and add operations guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ related articles into "stories", and posts them as toots/threads on Mastodon.
 
 ## Tech Stack
 
-- **Runtime:** Node.js ≥24, TypeScript (ESM), `tsx` for dev (older Node leaks RSS under worker-thread churn; supabase-js ≥2.106 needs native WebSocket of Node ≥22)
+- **Runtime:** Node.js ≥24, TypeScript (ESM), `tsx` for dev — see `docs/operations.md` for why 24 is the floor (worker-churn RSS leak on older Node)
 - **Scheduler:** [Bree](https://github.com/breejs/bree) — runs jobs in worker threads
 - **Mastodon client:** [`masto`](https://www.npmjs.com/package/masto)
 - **Database:** Supabase (Postgres) via `@supabase/supabase-js`
@@ -44,9 +44,14 @@ should ship with the bot; root `scripts/` is for ad-hoc cleanup.
 
 ## Database Tables
 
-- `tooted_hashes` — hash → timestamp; prevents re-posting articles whose RSS items reappear after deletion. Retention via `tooted_hash_retention_days` in settings.
+- `news` (configurable via `db_table` in settings) — main article store; rows carry `story_id`, `tooted`, `canonical_url`.
+- `stories` — one row per story (topic cluster); holds `toot_id` for threading and `original_links` for thread-level URL dedup.
+- `tooted_hashes` — hash + canonical_url → timestamp; prevents re-posting articles whose RSS items reappear after deletion, and backs the pre-claim that closes cross-run duplicate-post races. Retention via `tooted_hash_retention_days` in settings.
 - `bot_state` — key/JSONB store for cooldowns, pinned toots, last-toot timestamps (used by the adaptive tooter).
-- `news` (configurable via `db_table` in settings) — main article/story store.
+- `ai_usage` — per-call Claude cost log; `costTracker.ts` sheds low-priority AI features (polls before matching) as the daily budget runs out.
+- `regional_cache` / `semantic_pair_cache` — persistent AI-result caches (title → region category, title-pair → similarity score) so repeated classifications don't re-bill Claude. Helpers in `aiCache.ts` degrade to no-ops if the tables/env are missing.
+
+Schema lives in `migrations/` (numbered SQL files, applied manually to Supabase).
 
 ## Cron Schedule (defined in `src/index.ts`)
 
@@ -54,7 +59,7 @@ should ship with the bot; root `scripts/` is for ad-hoc cleanup.
 - `feed-tooter` — every 20 min, all day; decides itself whether to post (breaking vs. normal vs. cooldown)
 - `cleanup` — every 6 h
 - `cleanup-duplicates` — every 31 min
-- `mention-replier` — every 5 min
+- `mention-replier` — every 10 min
 - `story-thread-fixer` — 03:00 and 15:00 (fuzzy-matches existing toots into threads)
 - `daily-digest` — 22:00; `weekly-digest` — Sunday 20:00
 - `alive` — 30 min heartbeat
@@ -79,10 +84,17 @@ should ship with the bot; root `scripts/` is for ad-hoc cleanup.
 - Use delays between API calls (2-6 seconds)
 - On HTTP 429: wait 30 minutes before retrying
 
+### Bree Worker Contract
+- Every job MUST end with `parentPort.postMessage("done")` (or `process.exit(0)` when run standalone) on **every** exit path, including early returns — Bree only terminates the worker on that message.
+- Safety net: `closeWorkerAfterMs: 300_000` in `src/index.ts` kills any worker after 5 min; worker heaps are capped via `resourceLimits`.
+- Workers are threads of the main process — their memory counts toward one RSS. Think twice before adding new high-frequency jobs; worker churn is the bot's main memory pressure (see `docs/operations.md`).
+- URL dedup is layered: in-batch `Set` → DB pre-claim (`claimArticles`) → `tooted_hashes`. On any failure after a claim, roll back with `releaseCanonicalUrls` or the URL is permanently blocked.
+
 ## Common Commands
 
 ```bash
 npm run dev          # Run bot locally (tsx)
+npm start            # Production: write .env via scripts/create-env.cjs, run dist/index.js
 npm run build        # Compile TypeScript + copy settings.json to dist/
 npm test             # Run Jest tests (ESM mode)
 npm run test:coverage
@@ -110,6 +122,6 @@ Do's:
 
 Dont's:
 
-- Never post toots about the same topic multiple times as a major toot. toot
-differnt links about the same topic as threads under the first major toot. Never
-too the same URL more than once. EVER! ONLY ONCE ALWAYS!
+- Never post toots about the same topic multiple times as a major toot. Toot
+different links about the same topic as threads under the first major toot.
+Never toot the same URL more than once. EVER! ONLY ONCE ALWAYS!

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ src/
 
 ### Prerequisites
 
-- Node.js 24+ (older versions leak memory under Bree's worker-thread churn; `@supabase/supabase-js` ≥2.106 also requires the native `WebSocket` of Node ≥22)
+- Node.js 24+ (older versions leak memory under Bree's worker-thread churn; `@supabase/supabase-js` ≥2.106 also requires the native `WebSocket` of Node ≥22 — see [docs/operations.md](docs/operations.md))
 - A Mastodon account with API access
 - Supabase project (free tier works)
 - Claude API key (optional, for AI features)

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,83 @@
+# Operations
+
+Deployment and runtime notes for the Mastodon News Bot.
+
+## Running in production
+
+```bash
+npm run build   # tsc + copy settings.json to dist/data/
+npm start       # writes .env via scripts/create-env.cjs, then node ./dist/index.js
+```
+
+The bot is a single long-running Node process. Bree schedules every job as a
+short-lived **worker thread** inside that process (see `src/index.ts`), so all
+job memory and CPU show up under one PID.
+
+## Node version: why ≥24
+
+The bot spawns roughly 400 worker threads per day (feed-grabber ~80,
+feed-tooter 72, mention-replier 144, alive 48, cleanup-duplicates ~46, the
+rest ~10). Each worker loads the full dependency graph (supabase, masto,
+rss-parser, Anthropic SDK), runs once, and exits.
+
+Measured behavior (June 2026, synthetic churn test — workers importing the
+real dependency graph, terminated on `"done"`, parent RSS sampled):
+
+| Node    | Leaked RSS per worker | Pattern                |
+| ------- | --------------------- | ---------------------- |
+| 20.9    | ~40 KB                | linear, never plateaus |
+| 22.9    | ~17 KB                | slow drift             |
+| 24.16   | ~0                    | flat after warm-up     |
+
+Notes from the investigation:
+
+- The parent's JS heap stays flat in all cases — the growth is **native
+  memory inside the main process**, left behind per spawned worker by older
+  Node versions. App code was audited and is clean (all jobs signal `"done"`,
+  Bree 9.2.9 clears its timers and worker maps).
+- `MALLOC_ARENA_MAX=2` does **not** help, so it is not glibc arena
+  fragmentation — upgrading Node is the fix, not malloc tuning.
+- Independently, `@supabase/supabase-js` ≥2.106 throws inside
+  `createClient()` without native `WebSocket` (Node ≥22), so Node 20 cannot
+  run the bot at all anymore.
+
+On Node 20 the leak amounted to roughly 16 MB/day — the "RAM grows linearly
+every day" symptom.
+
+### Re-verifying after a Node upgrade
+
+Watch the process RSS for a day or two (e.g. `ps -o rss= -p <pid>` in a cron,
+or your process manager's metrics). Expect a warm-up climb for the first few
+hours, then flat. If it still climbs linearly, re-run a churn test: spawn a
+few hundred workers that import the dependency graph and sample
+`process.memoryUsage().rss` in the parent every ~50 runs.
+
+## Memory guardrails already in place
+
+- `closeWorkerAfterMs: 300_000` — any worker still alive after 5 min is
+  terminated (zombie protection).
+- Per-worker V8 heap caps: `maxOldGenerationSizeMb: 512`,
+  `maxYoungGenerationSizeMb: 128`.
+- Keep worker churn in mind when adding jobs: a new 5-minute job adds ~288
+  worker spawns/day. Prefer widening an existing job's scope over adding a
+  high-frequency job.
+
+## Recommended safety net
+
+Run under a supervisor with a memory ceiling and auto-restart, e.g. systemd:
+
+```ini
+[Service]
+ExecStart=/usr/bin/npm start
+Restart=always
+MemoryMax=1G
+```
+
+or pm2: `pm2 start npm --name news-bot -- start --max-memory-restart 800M`.
+
+## External rate limits
+
+- Mastodon API: ~300 requests / 5 min per account. Jobs sleep 2–6 s between
+  calls; on HTTP 429 back off 30 min.
+- Claude spend is budget-capped per day via the `ai_usage` table
+  (`src/helper/costTracker.ts`); low-priority features (polls) shed first.


### PR DESCRIPTION
## What

Follow-up to #54 (Node 24 / RAM leak). Captures the investigation knowledge in the repo so it isn't lost.

### CLAUDE.md
- Database section now lists **all** tables from `migrations/` (previously missing: `stories`, `ai_usage`, `regional_cache`, `semantic_pair_cache`) with one-line purpose each, plus the layered URL-dedup flow (in-batch Set → `claimArticles` pre-claim → `tooted_hashes`, with rollback rule).
- New **Bree Worker Contract** pattern: every job must `postMessage("done")` on every exit path; workers share the main process RSS; avoid adding high-frequency jobs.
- Fixed stale facts: `mention-replier` runs every 10 min (was documented as 5), added `npm start` to commands, fixed typos in the Dont's section.
- Runtime line now points to the new operations doc instead of inlining the leak story.

### docs/operations.md (new)
- Production run steps (`npm run build` + `npm start`).
- Node ≥24 rationale with the measured per-worker leak table (20.9: ~40 KB, 22.9: ~17 KB, 24.16: flat), why `MALLOC_ARENA_MAX` doesn't help, and how to re-verify after an upgrade.
- Existing memory guardrails (`closeWorkerAfterMs`, per-worker heap caps) and worker-churn budget guidance.
- Supervisor safety-net examples (systemd / pm2) and external rate limits.

### README.md
- Prerequisites line links to the operations doc.

## Test plan

- [x] Docs-only change; `git diff` reviewed, facts cross-checked against `src/index.ts` and `migrations/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)