### PR TITLE
fix(ai): stop re-billing regional classification every run

### DIFF
--- a/src/helper/costTracker.test.ts
+++ b/src/helper/costTracker.test.ts
@@ -28,15 +28,15 @@ describe("calculateCost", () => {
   });
 
   it("calculates cost for input tokens only", () => {
-    expect(calculateCost(1_000_000, 0)).toBeCloseTo(0.8);
+    expect(calculateCost(1_000_000, 0)).toBeCloseTo(1.0);
   });
 
   it("calculates cost for output tokens only", () => {
-    expect(calculateCost(0, 1_000_000)).toBeCloseTo(4.0);
+    expect(calculateCost(0, 1_000_000)).toBeCloseTo(5.0);
   });
 
   it("calculates combined cost", () => {
-    expect(calculateCost(500, 100)).toBeCloseTo(0.0008);
+    expect(calculateCost(500, 100)).toBeCloseTo(0.001);
   });
 });
 
@@ -100,7 +100,7 @@ describe("hasAiBudget", () => {
 
   it("uses default limit when no env var is configured", async () => {
     delete process.env.AI_DAILY_COST_LIMIT_USD;
-    mockRpc.mockResolvedValue({ data: 0.10, error: null }); // 50% of default 0.20
+    mockRpc.mockResolvedValue({ data: 0.02, error: null }); // 40% of default 0.05
 
     const result = await hasAiBudget();
     expect(result).toBe(true);
@@ -108,7 +108,7 @@ describe("hasAiBudget", () => {
 
   it("uses default limit when env var is 0 or invalid", async () => {
     process.env.AI_DAILY_COST_LIMIT_USD = "0";
-    mockRpc.mockResolvedValue({ data: 0.10, error: null }); // 50% of default 0.20
+    mockRpc.mockResolvedValue({ data: 0.02, error: null }); // 40% of default 0.05
 
     const result = await hasAiBudget();
     expect(result).toBe(true);
@@ -197,7 +197,7 @@ describe("AI_PRIORITY", () => {
 
 describe("DEFAULT_DAILY_LIMIT_USD", () => {
   it("is set to 0.15 (15 cents)", () => {
-    expect(DEFAULT_DAILY_LIMIT_USD).toBe(0.15);
+    expect(DEFAULT_DAILY_LIMIT_USD).toBe(0.05);
   });
 });
 
@@ -287,7 +287,7 @@ describe("hasAiBudgetForPriority", () => {
 
   it("uses default limit when env var not set", async () => {
     delete process.env.AI_DAILY_COST_LIMIT_USD;
-    mockRpc.mockResolvedValue({ data: 0.10, error: null }); // 67% of default 0.15
+    mockRpc.mockResolvedValue({ data: 0.033, error: null }); // 66% of default 0.05
 
     expect(await hasAiBudgetForPriority(AI_PRIORITY.LOW)).toBe(false);
     expect(await hasAiBudgetForPriority(AI_PRIORITY.MEDIUM)).toBe(false);

--- a/src/helper/costTracker.ts
+++ b/src/helper/costTracker.ts
@@ -1,12 +1,14 @@
 import createClient from "./db.js";
 
-// Pricing for claude-haiku-4-5-20251001
-const HAIKU_INPUT_COST_PER_M = 0.8;
-const HAIKU_OUTPUT_COST_PER_M = 4.0;
+// Pricing for claude-haiku-4-5-20251001 ($1/MTok in, $5/MTok out).
+// Keep in sync with the official price list - undercounting here makes the
+// budget gate fire too late and the real Anthropic bill exceed the limit.
+const HAIKU_INPUT_COST_PER_M = 1.0;
+const HAIKU_OUTPUT_COST_PER_M = 5.0;
 
-// Hard daily limit (15 cents) - can be overridden by AI_DAILY_COST_LIMIT_USD env var.
-// Sized so the monthly bill stays under ~€4.50 even at full daily usage.
-export const DEFAULT_DAILY_LIMIT_USD = 0.15;
+// Hard daily limit (5 cents) - can be overridden by AI_DAILY_COST_LIMIT_USD env var.
+// Sized so the monthly bill stays under ~$1.50 even at full daily usage.
+export const DEFAULT_DAILY_LIMIT_USD = 0.05;
 
 // Priority levels for AI features
 export const AI_PRIORITY = {

--- a/src/helper/engagementEnhancer.ts
+++ b/src/helper/engagementEnhancer.ts
@@ -104,7 +104,7 @@ export async function analyzeForPoll(
       messages: [{ role: "user", content: `Artikel: "${title}"` }],
     });
 
-    logAiUsage(
+    await logAiUsage(
       "poll_analysis",
       response.usage.input_tokens,
       response.usage.output_tokens

--- a/src/helper/hashtagGenerator.ts
+++ b/src/helper/hashtagGenerator.ts
@@ -148,7 +148,7 @@ async function getAiHashtags(
       messages: [{ role: "user", content: `Artikel: "${title}"` }],
     });
 
-    logAiUsage(
+    await logAiUsage(
       "hashtag_generation",
       response.usage.input_tokens,
       response.usage.output_tokens

--- a/src/helper/parseAiJson.test.ts
+++ b/src/helper/parseAiJson.test.ts
@@ -42,6 +42,25 @@ describe("parseAiJson", () => {
     expect(result).toEqual([{ a: 1, b: 2, s: 0.9 }]);
   });
 
+  it("salvages an array truncated mid-element (max_tokens cutoff)", () => {
+    const input = '[{"i":0,"c":"local"},{"i":1,"c":"nat';
+    const result = parseAiJson<{ i: number; c: string }[]>(input);
+    expect(result).toEqual([{ i: 0, c: "local" }]);
+  });
+
+  it("salvages an array truncated after a complete element", () => {
+    const input = '[{"i":0,"c":"local"},{"i":1,"c":"national"},';
+    const result = parseAiJson<{ i: number; c: string }[]>(input);
+    expect(result).toEqual([
+      { i: 0, c: "local" },
+      { i: 1, c: "national" },
+    ]);
+  });
+
+  it("throws on a truncated array with no complete element", () => {
+    expect(() => parseAiJson('[{"i":0,"c":"loc')).toThrow(SyntaxError);
+  });
+
   it("throws on invalid JSON", () => {
     expect(() => parseAiJson("not json")).toThrow(SyntaxError);
   });

--- a/src/helper/parseAiJson.ts
+++ b/src/helper/parseAiJson.ts
@@ -15,5 +15,18 @@ export function parseAiJson<T>(text: string): T {
     .replace(/\n?```\s*$/i, "")
     .trim();
 
-  return JSON.parse(cleaned);
+  try {
+    return JSON.parse(cleaned);
+  } catch (err) {
+    // Salvage arrays truncated by max_tokens: drop the incomplete trailing
+    // element and close the array, so the complete entries are not lost
+    // (losing them means cache misses and a re-billed API call next run).
+    if (cleaned.startsWith("[")) {
+      const lastComplete = cleaned.lastIndexOf("}");
+      if (lastComplete !== -1) {
+        return JSON.parse(cleaned.slice(0, lastComplete + 1) + "]");
+      }
+    }
+    throw err;
+  }
 }

--- a/src/helper/questionAnswerer.test.ts
+++ b/src/helper/questionAnswerer.test.ts
@@ -307,8 +307,9 @@ describe("answerQuestion", () => {
     );
   });
 
-  it("returns no-results when no keywords extracted", async () => {
+  it("falls back to programmatic keywords when AI extracts none", async () => {
     mockAiResponse("[]");
+    mockDb([]); // fallback keywords match nothing in DB
 
     const result = await answerQuestion(
       "user",
@@ -320,6 +321,22 @@ describe("answerQuestion", () => {
     expect(result).toContain(
       "Leider habe ich dazu keine passenden Nachrichten"
     );
+  });
+
+  it("answers via fallback keywords when AI budget is exhausted", async () => {
+    mockHasAiBudgetForSource.mockResolvedValue(false);
+    mockDb([
+      { data: { title: "Neuer Radweg", link: "https://example.com/1" } },
+    ]);
+
+    const result = await answerQuestion(
+      "user",
+      "<p>@saarlandnews Gibt es Neuigkeiten zum Radweg?</p>",
+      defaultSettings
+    );
+
+    expect(mockMessagesCreate).not.toHaveBeenCalled();
+    expect(result).toContain("Neuer Radweg");
   });
 
   it("returns articles when keywords and results found", async () => {

--- a/src/helper/questionAnswerer.ts
+++ b/src/helper/questionAnswerer.ts
@@ -34,6 +34,31 @@ export function sanitizeHtml(html: string): string {
   return text.trim();
 }
 
+// Common German question/filler words that make useless search terms.
+const FALLBACK_STOPWORDS = new Set([
+  "aber", "alle", "auch", "beim", "bitte", "dann", "dass", "dein", "diese",
+  "dieser", "dieses", "doch", "eine", "einem", "einen", "einer", "eines",
+  "etwas", "gibt", "habe", "haben", "hallo", "heute", "ihre", "kann",
+  "können", "letzte", "letzten", "mich", "mein", "meine", "neues", "nicht",
+  "noch", "oder", "passiert", "schon", "sein", "sind", "über", "viel",
+  "wann", "warum", "weißt", "welche", "wenn", "werden", "wieder", "wird",
+  "wurde", "zum", "zur",
+]);
+
+/**
+ * Programmatic keyword extraction - used when the AI budget is exhausted or
+ * the API is unavailable, so mention replies keep working without Claude.
+ */
+export function extractKeywordsFallback(text: string): string[] {
+  const words = text
+    .split(/[^a-zA-ZäöüÄÖÜß0-9-]+/)
+    .map((w) => w.trim())
+    .filter(
+      (w) => w.length >= 4 && !FALLBACK_STOPWORDS.has(w.toLowerCase())
+    );
+  return [...new Set(words)].slice(0, 7);
+}
+
 function buildTsQuery(keywords: string[]): string {
   return keywords
     .map((kw) => kw.replace(/[^a-zA-ZäöüÄÖÜßéèêàáâ0-9]/g, ""))
@@ -63,7 +88,7 @@ export async function extractKeywords(text: string): Promise<string[]> {
       messages: [{ role: "user", content: text }],
     });
 
-    logAiUsage(
+    await logAiUsage(
       "question_answerer",
       response.usage.input_tokens,
       response.usage.output_tokens
@@ -195,7 +220,13 @@ export async function answerQuestion(
     return `@${userAcct} ${noResultsText}`;
   }
 
-  const keywords = await extractKeywords(text);
+  let keywords = await extractKeywords(text);
+
+  // AI unavailable (budget, key, error) - degrade to programmatic extraction
+  // so the bot still answers instead of going silent.
+  if (keywords.length === 0) {
+    keywords = extractKeywordsFallback(text);
+  }
 
   if (keywords.length === 0) {
     return `@${userAcct} ${noResultsText}`;

--- a/src/helper/regionalRelevance.test.ts
+++ b/src/helper/regionalRelevance.test.ts
@@ -224,6 +224,77 @@ describe("scoreRegionalRelevance", () => {
     expect(mockMessagesCreate).not.toHaveBeenCalled();
   });
 
+  it("classifies titles matching local_keywords without API call", async () => {
+    const config = {
+      ...defaultConfig,
+      local_keywords: ["saarbrücken", "saarlouis"],
+    };
+
+    const articles = [
+      { title: "Brand in Saarbrücken", feedKey: "saarbruecker-zeitung" },
+      { title: "Stau bei Saarlouis", feedKey: "radio-salue" },
+    ];
+
+    const result = await scoreRegionalRelevance(articles, config);
+
+    expect(result.get(0)).toBe(1.5);
+    expect(result.get(1)).toBe(1.5);
+    expect(mockMessagesCreate).not.toHaveBeenCalled();
+  });
+
+  it("sends only non-keyword titles to the API", async () => {
+    const config = { ...defaultConfig, local_keywords: ["saarbrücken"] };
+    mockApiResponse(JSON.stringify([{ i: 1, c: "national" }]));
+
+    const articles = [
+      { title: "Brand in Saarbrücken", feedKey: "saarbruecker-zeitung" },
+      { title: "Bundestagswahl", feedKey: "tagesschau" },
+    ];
+
+    const result = await scoreRegionalRelevance(articles, config);
+
+    expect(result.get(0)).toBe(1.5); // keyword match, no AI
+    expect(result.get(1)).toBe(1.0); // AI classified
+    expect(mockMessagesCreate).toHaveBeenCalledTimes(1);
+    const call = mockMessagesCreate.mock.calls[0][0] as any;
+    expect(call.messages[0].content).not.toContain("Saarbrücken");
+  });
+
+  it("splits large batches into chunks with sized max_tokens", async () => {
+    // 30 articles -> 2 chunks (25 + 5)
+    mockMessagesCreate.mockImplementation(async (req: any) => {
+      // Echo back a classification for every index mentioned in the prompt
+      const indices = [...req.messages[0].content.matchAll(/^(\d+):/gm)].map(
+        (m: any) => Number(m[1])
+      );
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(indices.map((i: number) => ({ i, c: "national" }))),
+          },
+        ],
+        usage: { input_tokens: 200, output_tokens: 80 },
+      };
+    });
+
+    const articles = Array.from({ length: 30 }, (_, i) => ({
+      title: `Artikel ${i}`,
+      feedKey: "tagesschau",
+    }));
+
+    const result = await scoreRegionalRelevance(articles, defaultConfig);
+
+    expect(mockMessagesCreate).toHaveBeenCalledTimes(2);
+    const firstCall = mockMessagesCreate.mock.calls[0][0] as any;
+    const secondCall = mockMessagesCreate.mock.calls[1][0] as any;
+    expect(firstCall.max_tokens).toBe(25 * 16 + 64);
+    expect(secondCall.max_tokens).toBe(5 * 16 + 64);
+    for (let i = 0; i < 30; i++) {
+      expect(result.get(i)).toBe(1.0);
+    }
+  });
+
   it("fills missing indices with neutral multiplier when AI omits them (line 150)", async () => {
     // AI response is missing index 1 entirely
     mockApiResponse(JSON.stringify([{ i: 0, c: "local" }]));

--- a/src/helper/regionalRelevance.ts
+++ b/src/helper/regionalRelevance.ts
@@ -27,6 +27,19 @@ const SYSTEM_PROMPT = `Klassifiziere Saarland-Nachrichten:
 
 Nur JSON-Array: [{"i":0,"c":"local"},...]`;
 
+// Max titles per API call. Output budget is sized per chunk; oversized
+// batches previously hit max_tokens, truncated the JSON, and re-billed the
+// same titles on every run because nothing reached the cache.
+const AI_CHUNK_SIZE = 25;
+// Worst-case output tokens per array entry ("{\"i\":123,\"c\":\"international\"},").
+const OUTPUT_TOKENS_PER_ENTRY = 16;
+
+function titleMatchesLocalKeyword(title: string, keywords: string[]): boolean {
+  if (keywords.length === 0) return false;
+  const lower = title.toLowerCase();
+  return keywords.some((kw) => lower.includes(kw.toLowerCase()));
+}
+
 function buildUserPrompt(articles: { index: number; title: string }[]): string {
   const lines = articles.map((a) => `${a.index}: ${a.title}`);
   return `Klassifiziere diese Artikel:\n${lines.join("\n")}`;
@@ -53,15 +66,28 @@ export async function scoreRegionalRelevance(
   }
 
   const alwaysLocal = new Set(config.always_local_feeds ?? []);
+  const localKeywords = config.local_keywords ?? [];
   const toClassify: { index: number; title: string }[] = [];
+  let keywordLocalCount = 0;
 
   for (let i = 0; i < articles.length; i++) {
     const a = articles[i];
     if (a.feedKey && alwaysLocal.has(a.feedKey)) {
       result.set(i, categoryToMultiplier("local", config));
+    } else if (titleMatchesLocalKeyword(a.title, localKeywords)) {
+      // Free programmatic classification: a Saarland place name in the title
+      // means "local" - no need to pay Claude to confirm that.
+      result.set(i, categoryToMultiplier("local", config));
+      keywordLocalCount++;
     } else {
       toClassify.push({ index: i, title: a.title });
     }
+  }
+
+  if (keywordLocalCount > 0) {
+    console.log(
+      `Regional relevance: ${keywordLocalCount} articles classified local via keyword match (no AI)`
+    );
   }
 
   if (toClassify.length === 0) {
@@ -99,81 +125,74 @@ export async function scoreRegionalRelevance(
     return result;
   }
 
-  try {
-    if (!(await hasAiBudgetForSource("regional_relevance"))) {
-      console.warn(
-        "Regional relevance: AI budget threshold reached, using neutral multipliers"
+  const counts: Record<string, number> = {
+    local: 0,
+    regional: 0,
+    national: 0,
+    international: 0,
+  };
+  const client = getAnthropicClient(apiKey);
+  const indexToTitle = new Map(stillToClassify.map((t) => [t.index, t.title]));
+
+  for (let start = 0; start < stillToClassify.length; start += AI_CHUNK_SIZE) {
+    const chunk = stillToClassify.slice(start, start + AI_CHUNK_SIZE);
+    try {
+      // Re-check between chunks so a long backlog can't blow past the limit.
+      if (!(await hasAiBudgetForSource("regional_relevance"))) {
+        console.warn(
+          "Regional relevance: AI budget threshold reached, using neutral multipliers for remaining articles"
+        );
+        break;
+      }
+
+      const response = await client.messages.create({
+        model: "claude-haiku-4-5-20251001",
+        max_tokens: chunk.length * OUTPUT_TOKENS_PER_ENTRY + 64,
+        system: SYSTEM_PROMPT,
+        messages: [{ role: "user", content: buildUserPrompt(chunk) }],
+      });
+
+      await logAiUsage(
+        "regional_relevance",
+        response.usage.input_tokens,
+        response.usage.output_tokens
       );
-      for (const item of stillToClassify) {
-        result.set(item.index, 1.0);
+
+      const text =
+        response.content[0].type === "text" ? response.content[0].text : "";
+      const parsed = parseAiJson<{ i: number; c: RelevanceCategory }[]>(text);
+
+      const toCache: { title: string; category: RelevanceCategory }[] = [];
+      for (const entry of parsed) {
+        const multiplier = categoryToMultiplier(entry.c, config);
+        result.set(entry.i, multiplier);
+        if (entry.c in counts) counts[entry.c]++;
+        const title = indexToTitle.get(entry.i);
+        if (title) toCache.push({ title, category: entry.c });
       }
-      return result;
-    }
 
-    const client = getAnthropicClient(apiKey);
-    const response = await client.messages.create({
-      model: "claude-haiku-4-5-20251001",
-      max_tokens: 160,
-      system: SYSTEM_PROMPT,
-      messages: [{ role: "user", content: buildUserPrompt(stillToClassify) }],
-    });
-
-    logAiUsage(
-      "regional_relevance",
-      response.usage.input_tokens,
-      response.usage.output_tokens
-    );
-
-    const text =
-      response.content[0].type === "text" ? response.content[0].text : "";
-    const parsed = parseAiJson<{ i: number; c: RelevanceCategory }[]>(text);
-
-    const counts: Record<string, number> = {
-      local: 0,
-      regional: 0,
-      national: 0,
-      international: 0,
-    };
-
-    const toCache: { title: string; category: RelevanceCategory }[] = [];
-    const indexToTitle = new Map(
-      stillToClassify.map((t) => [t.index, t.title])
-    );
-    for (const entry of parsed) {
-      const multiplier = categoryToMultiplier(entry.c, config);
-      result.set(entry.i, multiplier);
-      if (entry.c in counts) counts[entry.c]++;
-      const title = indexToTitle.get(entry.i);
-      if (title) toCache.push({ title, category: entry.c });
-    }
-
-    // Persist fresh classifications so future runs hit the cache.
-    await setCachedRegionalCategories(toCache);
-
-    // Fill any missing indices with neutral multiplier
-    for (const item of stillToClassify) {
-      if (!result.has(item.index)) {
-        result.set(item.index, 1.0);
-      }
-    }
-
-    // Count always-local articles
-    const alwaysLocalCount = articles.length - toClassify.length;
-    counts.local += alwaysLocalCount;
-
-    console.log(
-      `Regional relevance scored ${articles.length} articles: ${counts.local} local, ${counts.regional} regional, ${counts.national} national, ${counts.international} international`
-    );
-  } catch (err) {
-    console.error(
-      `Regional relevance API call failed, using neutral multipliers: ${err}`
-    );
-    for (const item of stillToClassify) {
-      if (!result.has(item.index)) {
-        result.set(item.index, 1.0);
-      }
+      // Persist fresh classifications so future runs hit the cache.
+      await setCachedRegionalCategories(toCache);
+    } catch (err) {
+      console.error(
+        `Regional relevance API call failed, using neutral multipliers: ${err}`
+      );
     }
   }
+
+  // Fill any missing indices with neutral multiplier
+  for (const item of stillToClassify) {
+    if (!result.has(item.index)) {
+      result.set(item.index, 1.0);
+    }
+  }
+
+  // Count always-local and keyword-local articles
+  counts.local += articles.length - toClassify.length;
+
+  console.log(
+    `Regional relevance scored ${articles.length} articles: ${counts.local} local, ${counts.regional} regional, ${counts.national} national, ${counts.international} international`
+  );
 
   return result;
 }

--- a/src/helper/semanticSimilarity.ts
+++ b/src/helper/semanticSimilarity.ts
@@ -96,7 +96,7 @@ export async function batchSemanticSimilarity(
       messages: [{ role: "user", content: userPrompt }],
     });
 
-    logAiUsage(
+    await logAiUsage(
       "semantic_similarity",
       response.usage.input_tokens,
       response.usage.output_tokens

--- a/src/jobs/feed-tooter.ts
+++ b/src/jobs/feed-tooter.ts
@@ -224,11 +224,17 @@ type StoryInfo = {
         title: a.article.title ?? "",
         feedKey: a.feedKey,
       })),
-      (settings as any).regional_relevance ?? {
-        enabled: false,
-        always_local_feeds: [],
-        multipliers: { local: 1, regional: 1, national: 1, international: 1 },
-      }
+      (settings as any).regional_relevance
+        ? {
+            ...(settings as any).regional_relevance,
+            // Saarland gazetteer: titles matching these are local without AI.
+            local_keywords: (settings as any).keyword_filter?.keywords ?? [],
+          }
+        : {
+            enabled: false,
+            always_local_feeds: [],
+            multipliers: { local: 1, regional: 1, national: 1, international: 1 },
+          }
     );
 
     for (let i = 0; i < allArticlesForScoring.length; i++) {

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -13,6 +13,12 @@ type SingleCWMapping = {
 export type RegionalRelevanceSettings = {
   enabled: boolean;
   always_local_feeds: string[];
+  /**
+   * Saarland place names / keywords: a title containing one is classified
+   * "local" programmatically, skipping the AI call. Usually wired from
+   * keyword_filter.keywords by the caller.
+   */
+  local_keywords?: string[];
   multipliers: {
     local: number;
     regional: number;


### PR DESCRIPTION
## Problem

Since v1.3.0 the AI bill jumped to 30–40 ct/day. Live `ai_usage` data showed `regional_relevance` burning ~85% of the spend (~46 calls/day, ~150k input tokens/day) with **output tokens pinned at exactly 160 on every single call** — the `max_tokens: 160` cap.

Root cause chain:

1. v1.3.0 removed `saarbruecker-zeitung` and `radio-salue` from `always_local_feeds`, so ~100 titles per run hit the AI classifier.
2. 100 titles need ~1,600 output tokens; the response truncated at 160, `JSON.parse` threw, and all results were discarded.
3. Because parsing failed, **nothing was written to `regional_cache` since 2026-05-19** — every 20-minute `feed-tooter` run re-classified (and re-billed) the same titles, forever.
4. Tracked cost understated the real bill: pricing constants were \$0.8/\$4 per MTok (Haiku 4.5 is \$1/\$5), and `logAiUsage` was fire-and-forget, so inserts were dropped when the Bree worker exited.

## Fix

- **Keyword gazetteer first**: titles matching `keyword_filter.keywords` (Saarland place names) are classified `local` programmatically — no API call. Since the v1.3.0 keyword filter already requires a Saarland match, this covers most articles for free.
- **Chunked AI classification**: remaining titles go to Claude in chunks of 25 with `max_tokens` sized per chunk; budget re-checked between chunks; cache written per chunk.
- **Truncation salvage** in `parseAiJson`: complete array entries survive a `max_tokens` cutoff instead of being lost.
- **Correct pricing** (\$1/\$5 per MTok) so the budget gate fires on time.
- **`await logAiUsage`** in all five AI helpers so spend is recorded before worker exit.
- **Default daily limit lowered** \$0.15 → \$0.05 (~\$1.50/month ceiling).
- **Graceful degradation**: when the budget is exhausted, mention replies fall back to programmatic keyword extraction instead of going silent; hashtags/polls/semantic matching already shed in priority order.

Expected spend after this: ~\$0.02/day, hard-capped at \$0.05.

## ⚠️ Deployment note

The server likely sets `AI_DAILY_COST_LIMIT_USD` (observed spend pattern matches ≈0.30). That env var **overrides** the new default — remove it or lower it to 0.05.

## Testing

- 589/589 Jest tests pass (new tests: gazetteer, chunk sizing, JSON salvage, Q&A fallback)
- `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)