### PR TITLE
fix: eliminate hung-worker memory pressure by bounding all in-worker waits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,7 @@ Schema lives in `migrations/` (numbered SQL files, applied manually to Supabase)
 
 ### Bree Worker Contract
 - Every job MUST end with `parentPort.postMessage("done")` (or `process.exit(0)` when run standalone) on **every** exit path, including early returns — Bree only terminates the worker on that message.
+- Every network await and retry/backoff budget inside a worker must be bounded **well below 300s** (the `closeWorkerAfterMs` kill window) — see the per-dependency timeout table in `docs/operations.md`. Never `sleep()` out a rate limit inside a worker; stop the run cleanly and let the next scheduled run resume.
 - Safety net: `closeWorkerAfterMs: 300_000` in `src/index.ts` kills any worker after 5 min; worker heaps are capped via `resourceLimits`.
 - Workers are threads of the main process — their memory counts toward one RSS. Think twice before adding new high-frequency jobs; worker churn is the bot's main memory pressure (see `docs/operations.md`).
 - URL dedup is layered: in-batch `Set` → DB pre-claim (`claimArticles`) → `tooted_hashes`. On any failure after a claim, roll back with `releaseCanonicalUrls` or the URL is permanently blocked.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -21,12 +21,14 @@ rest ~10). Each worker loads the full dependency graph (supabase, masto,
 rss-parser, Anthropic SDK), runs once, and exits.
 
 Measured behavior (June 2026, synthetic churn test — workers importing the
-real dependency graph, terminated on `"done"`, parent RSS sampled):
+real dependency graph, terminated on `"done"`, parent RSS sampled; the
+24.10.0 row was added July 2026):
 
 | Node    | Leaked RSS per worker | Pattern                |
 | ------- | --------------------- | ---------------------- |
 | 20.9    | ~40 KB                | linear, never plateaus |
 | 22.9    | ~17 KB                | slow drift             |
+| 24.10   | ~0                    | flat after warm-up     |
 | 24.16   | ~0                    | flat after warm-up     |
 
 Notes from the investigation:
@@ -44,6 +46,23 @@ Notes from the investigation:
 On Node 20 the leak amounted to roughly 16 MB/day — the "RAM grows linearly
 every day" symptom.
 
+### The leak class is gone on 24.10.0 — don't chase Node versions further
+
+A July 2026 re-investigation churn-tested the exact production binary
+(v24.10.0) with the real dependency graph and Bree's exact lifecycle,
+including a force-kill variant (700 consecutive `terminate()`s of workers
+holding sockets and timers): parent RSS flat in both, identical to 24.16.
+A release-by-release review of v24.11.0–v24.16.0 found no worker_threads
+memory fix in that window — whatever made 24.16 measure ~0 was already in
+24.10.0. If the container still grows linearly on ≥24.10, the cause is not
+the Node worker-churn leak; look at hung workers and in-worker workloads
+(next section).
+
+**Warning:** v24.16.0 ships a known fetch memory-leak *regression*
+(nodejs/node#63708 / #63574: bodies retained after `AbortSignal.timeout`
+aborts, not present in v24.15.0). If upgrading, prefer 24.15.0 or verify the
+issue is fixed in the target's release notes first.
+
 ### Re-verifying after a Node upgrade
 
 Watch the process RSS for a day or two (e.g. `ps -o rss= -p <pid>` in a cron,
@@ -51,6 +70,39 @@ or your process manager's metrics). Expect a warm-up climb for the first few
 hours, then flat. If it still climbs linearly, re-run a churn test: spawn a
 few hundred workers that import the dependency graph and sample
 `process.memoryUsage().rss` in the parent every ~50 runs.
+
+## Hung workers: every await must stay below the 300s kill window
+
+`closeWorkerAfterMs: 300_000` is a safety net, not an exit path. A worker
+that never posts `"done"` sits for the full 5 minutes holding its complete
+dependency-graph heap (supabase + masto + Anthropic SDK + rss-parser, easily
+50–100 MB) plus live TLS sockets before being force-killed — and overlapping
+hung workers are what raise the container's memory baseline. Every network
+await and retry budget in a job must therefore be bounded **well below
+300 s**. Current budgets:
+
+| Dependency  | Bound                                       | Where                        |
+| ----------- | ------------------------------------------- | ---------------------------- |
+| Supabase    | 30 s/request, 3 attempts                    | `src/helper/db.ts`           |
+| Mastodon    | 30 s/request                                | `src/helper/login.ts`        |
+| Anthropic   | 60 s/request, 1 retry                       | the five AI helpers          |
+| RSS feeds   | 15 s/fetch (native fetch, aborts for real)  | `src/helper/getFeed.ts`      |
+| Images      | 15 s total incl. body                       | `src/helper/fetchImage.ts`   |
+| 429 backoff | ≤35 s (cleanup-duplicates), ≤45 s (fixer)   | the respective jobs          |
+
+Never `sleep()` out a rate limit inside a worker: stop the run cleanly
+(post `"done"`) and let the next scheduled run resume — Mastodon's
+rate-limit window (~5 min) is always shorter than any job's schedule gap.
+
+### Reading the hourly memory telemetry
+
+`src/index.ts` logs a `[memory]` line every hour. To classify growth on the
+Railway graph (which counts the whole cgroup, including page cache):
+
+- `rss`/`anon` climbing → real process leak (heap or native).
+- `rss` flat, `file` climbing → kernel page cache, not a leak.
+- `workersAlive` frequently > 0 between runs → hung workers; check for a
+  job awaiting something unbounded (see table above).
 
 ## Memory guardrails already in place
 

--- a/src/helper/engagementEnhancer.ts
+++ b/src/helper/engagementEnhancer.ts
@@ -4,7 +4,10 @@ import { parseAiJson } from "./parseAiJson.js";
 
 let _anthropicClient: Anthropic | null = null;
 function getAnthropicClient(apiKey: string): Anthropic {
-  if (!_anthropicClient) _anthropicClient = new Anthropic({ apiKey });
+  // SDK defaults (10 min timeout × 2 retries) can pin a worker far past
+  // Bree's 300s force-kill; callers all degrade gracefully on error.
+  if (!_anthropicClient)
+    _anthropicClient = new Anthropic({ apiKey, timeout: 60_000, maxRetries: 1 });
   return _anthropicClient;
 }
 

--- a/src/helper/fetchImage.test.ts
+++ b/src/helper/fetchImage.test.ts
@@ -96,25 +96,20 @@ describe("fetchImage", () => {
     expect(result!.type).toBe("image/jpeg");
   });
 
-  test("timeout callback aborts the request after 15 seconds", async () => {
-    jest.useFakeTimers();
+  test("passes a timeout signal covering the whole request", async () => {
+    // AbortSignal.timeout runs on Node-internal timers that Jest cannot
+    // fake, so assert the wiring: the signal reaches fetch, and a
+    // TimeoutError from it maps to a null result.
     let signalRef: AbortSignal | undefined;
     globalThis.fetch = jest.fn<typeof fetch>().mockImplementation((_, init) => {
       signalRef = (init as RequestInit)?.signal as AbortSignal | undefined;
-      return new Promise((_, reject) => {
-        if (signalRef) {
-          signalRef.addEventListener("abort", () =>
-            reject(new DOMException("The operation was aborted.", "AbortError"))
-          );
-        }
-      });
+      return Promise.reject(
+        new DOMException("The operation was aborted due to timeout", "TimeoutError")
+      );
     });
 
-    const resultPromise = fetchImage("https://example.com/slow.png");
-    jest.advanceTimersByTime(15001);
-    const result = await resultPromise;
+    const result = await fetchImage("https://example.com/slow.png");
     expect(result).toBeNull();
-    expect(signalRef?.aborted).toBe(true);
-    jest.useRealTimers();
+    expect(signalRef).toBeInstanceOf(AbortSignal);
   });
 });

--- a/src/helper/fetchImage.ts
+++ b/src/helper/fetchImage.ts
@@ -3,28 +3,30 @@
  * Uses native fetch API with timeout and redirect handling.
  * Returns null if the download fails or the content is not an image.
  */
+const FETCH_TIMEOUT_MS = 15000;
+
 const fetchImage = async (url: string): Promise<Blob | null> => {
   try {
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 15000);
-
+    // One deadline for headers AND body: a slow-drip server must not be able
+    // to hold the worker open past the timeout (undici's own bodyTimeout is
+    // idle-based and resets on every chunk).
     const response = await fetch(url, {
-      signal: controller.signal,
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
       headers: {
         "User-Agent": "MastodonNewsBot/2.0",
       },
       redirect: "follow",
     });
 
-    clearTimeout(timeoutId);
-
     if (!response.ok) {
+      await response.body?.cancel().catch(() => {});
       console.log(`Image fetch failed (${response.status}): ${url}`);
       return null;
     }
 
     const contentType = response.headers.get("content-type") || "";
     if (!contentType.startsWith("image/")) {
+      await response.body?.cancel().catch(() => {});
       console.log(`Not an image (${contentType}): ${url}`);
       return null;
     }
@@ -32,7 +34,8 @@ const fetchImage = async (url: string): Promise<Blob | null> => {
     const arrayBuffer = await response.arrayBuffer();
     return new Blob([arrayBuffer], { type: contentType });
   } catch (e) {
-    if ((e as Error).name === "AbortError") {
+    const name = (e as Error).name;
+    if (name === "TimeoutError" || name === "AbortError") {
       console.log(`Image fetch timeout: ${url}`);
     } else {
       console.log(`Image fetch error for ${url}: ${e}`);

--- a/src/helper/getFeed.test.ts
+++ b/src/helper/getFeed.test.ts
@@ -1,18 +1,31 @@
-import { jest, describe, test, expect, beforeEach } from "@jest/globals";
+import { jest, describe, test, expect, beforeEach, afterEach } from "@jest/globals";
 
-const mockParseURL = jest.fn();
+const mockParseString = jest.fn();
 
 jest.unstable_mockModule("rss-parser", () => ({
   default: jest.fn().mockImplementation(() => ({
-    parseURL: mockParseURL,
+    parseString: mockParseString,
   })),
 }));
 
 const { default: getFeed } = await import("./getFeed.js");
 
+const xmlResponse = (body: string, init?: ResponseInit) =>
+  new Response(body, {
+    status: 200,
+    headers: { "content-type": "application/rss+xml; charset=utf-8" },
+    ...init,
+  });
+
 describe("getFeed", () => {
+  const originalFetch = globalThis.fetch;
+
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
   });
 
   test("returns parsed feed on success", async () => {
@@ -22,43 +35,92 @@ describe("getFeed", () => {
         { title: "Article 2", link: "https://example.com/2" },
       ],
     };
-    mockParseURL.mockResolvedValue(mockFeed);
+    globalThis.fetch = jest
+      .fn<typeof fetch>()
+      .mockResolvedValue(xmlResponse("<rss/>"));
+    mockParseString.mockResolvedValue(mockFeed);
 
     const result = await getFeed("https://example.com/feed");
     expect(result).toEqual(mockFeed);
     expect(result!.items).toHaveLength(2);
+    expect(mockParseString).toHaveBeenCalledWith("<rss/>");
+  });
+
+  test("passes an abort signal so a hung transfer cannot outlive the timeout", async () => {
+    globalThis.fetch = jest
+      .fn<typeof fetch>()
+      .mockResolvedValue(xmlResponse("<rss/>"));
+    mockParseString.mockResolvedValue({ items: [] });
+
+    await getFeed("https://example.com/feed");
+
+    const init = (globalThis.fetch as jest.Mock).mock.calls[0][1] as RequestInit;
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  test("decodes ISO-8859-1 bodies via the content-type charset", async () => {
+    // "Saarbrücken" with the ü encoded as latin-1 byte 0xFC
+    const latin1 = new Uint8Array([
+      0x53, 0x61, 0x61, 0x72, 0x62, 0x72, 0xfc, 0x63, 0x6b, 0x65, 0x6e,
+    ]);
+    globalThis.fetch = jest.fn<typeof fetch>().mockResolvedValue(
+      new Response(latin1, {
+        status: 200,
+        headers: { "content-type": "text/xml; charset=iso-8859-1" },
+      })
+    );
+    mockParseString.mockResolvedValue({ items: [] });
+
+    await getFeed("https://example.com/feed");
+    expect(mockParseString).toHaveBeenCalledWith("Saarbrücken");
   });
 
   test("returns null on general error", async () => {
-    mockParseURL.mockRejectedValue(new Error("Network failure"));
+    globalThis.fetch = jest
+      .fn<typeof fetch>()
+      .mockRejectedValue(new Error("Network failure"));
 
     const result = await getFeed("https://example.com/feed");
     expect(result).toBeNull();
   });
 
-  test("returns null on 503 status (temporary unavailability)", async () => {
-    mockParseURL.mockRejectedValue(new Error("Status code 503"));
+  test("returns null on timeout", async () => {
+    const timeoutError = new Error("The operation was aborted due to timeout");
+    timeoutError.name = "TimeoutError";
+    globalThis.fetch = jest.fn<typeof fetch>().mockRejectedValue(timeoutError);
 
     const result = await getFeed("https://example.com/feed");
     expect(result).toBeNull();
   });
 
-  test("returns null on 502 status", async () => {
-    mockParseURL.mockRejectedValue(new Error("Status code 502"));
+  test.each(["503", "502", "504"])(
+    "returns null on %s status (temporary unavailability)",
+    async (status) => {
+      globalThis.fetch = jest
+        .fn<typeof fetch>()
+        .mockResolvedValue(new Response(null, { status: Number(status) }));
 
-    const result = await getFeed("https://example.com/feed");
-    expect(result).toBeNull();
-  });
+      const result = await getFeed("https://example.com/feed");
+      expect(result).toBeNull();
+      expect(mockParseString).not.toHaveBeenCalled();
+    }
+  );
 
-  test("returns null on 504 status", async () => {
-    mockParseURL.mockRejectedValue(new Error("Status code 504"));
+  test("returns null on parse error", async () => {
+    globalThis.fetch = jest
+      .fn<typeof fetch>()
+      .mockResolvedValue(xmlResponse("not xml"));
+    mockParseString.mockRejectedValue(new Error("Feed not recognized as RSS 1 or 2."));
 
     const result = await getFeed("https://example.com/feed");
     expect(result).toBeNull();
   });
 
   test("returns feed with empty items array", async () => {
-    mockParseURL.mockResolvedValue({ items: [] });
+    globalThis.fetch = jest
+      .fn<typeof fetch>()
+      .mockResolvedValue(xmlResponse("<rss/>"));
+    mockParseString.mockResolvedValue({ items: [] });
 
     const result = await getFeed("https://example.com/empty-feed");
     expect(result).toEqual({ items: [] });
@@ -66,7 +128,7 @@ describe("getFeed", () => {
   });
 
   test("handles error without message property", async () => {
-    mockParseURL.mockRejectedValue("string error");
+    globalThis.fetch = jest.fn<typeof fetch>().mockRejectedValue("string error");
 
     const result = await getFeed("https://example.com/feed");
     expect(result).toBeNull();

--- a/src/helper/getFeed.test.ts
+++ b/src/helper/getFeed.test.ts
@@ -1,4 +1,11 @@
-import { jest, describe, test, expect, beforeEach, afterEach } from "@jest/globals";
+import {
+  jest,
+  describe,
+  test,
+  expect,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
 
 const mockParseString = jest.fn();
 
@@ -54,7 +61,8 @@ describe("getFeed", () => {
 
     await getFeed("https://example.com/feed");
 
-    const init = (globalThis.fetch as jest.Mock).mock.calls[0][1] as RequestInit;
+    const init = (globalThis.fetch as jest.Mock).mock
+      .calls[0][1] as RequestInit;
     expect(init.signal).toBeInstanceOf(AbortSignal);
   });
 
@@ -67,7 +75,7 @@ describe("getFeed", () => {
       new Response(latin1, {
         status: 200,
         headers: { "content-type": "text/xml; charset=iso-8859-1" },
-      })
+      }),
     );
     mockParseString.mockResolvedValue({ items: [] });
 
@@ -103,14 +111,16 @@ describe("getFeed", () => {
       const result = await getFeed("https://example.com/feed");
       expect(result).toBeNull();
       expect(mockParseString).not.toHaveBeenCalled();
-    }
+    },
   );
 
   test("returns null on parse error", async () => {
     globalThis.fetch = jest
       .fn<typeof fetch>()
       .mockResolvedValue(xmlResponse("not xml"));
-    mockParseString.mockRejectedValue(new Error("Feed not recognized as RSS 1 or 2."));
+    mockParseString.mockRejectedValue(
+      new Error("Feed not recognized as RSS 1 or 2."),
+    );
 
     const result = await getFeed("https://example.com/feed");
     expect(result).toBeNull();
@@ -128,7 +138,9 @@ describe("getFeed", () => {
   });
 
   test("handles error without message property", async () => {
-    globalThis.fetch = jest.fn<typeof fetch>().mockRejectedValue("string error");
+    globalThis.fetch = jest
+      .fn<typeof fetch>()
+      .mockRejectedValue("string error");
 
     const result = await getFeed("https://example.com/feed");
     expect(result).toBeNull();

--- a/src/helper/getFeed.ts
+++ b/src/helper/getFeed.ts
@@ -1,25 +1,63 @@
 import Parser from "rss-parser";
 
+// Fetch the XML ourselves instead of using parser.parseURL():
+// rss-parser's own network layer never destroys the request on timeout,
+// non-2xx, or redirect (rbren/rss-parser#238, unfixed upstream), leaving the
+// socket open and the response buffering for the rest of the worker's life.
+// Native fetch aborts the transfer for real via AbortSignal.timeout.
+const FETCH_TIMEOUT_MS = 15000;
+
+const FETCH_HEADERS = {
+  "User-Agent": "MastodonNewsBot/2.0 (RSS Reader)",
+  Accept: "application/rss+xml, application/xml, text/xml",
+};
+
 // Reuse parser instance across calls (avoid re-creating)
-const parser = new Parser({
-  timeout: 15000,
-  headers: {
-    "User-Agent": "MastodonNewsBot/2.0 (RSS Reader)",
-    Accept: "application/rss+xml, application/xml, text/xml",
-  },
-  maxRedirects: 3,
-});
+const parser = new Parser();
+
+/**
+ * Decode the response body honoring the charset from the Content-Type header
+ * (some German feeds still serve ISO-8859-1); falls back to UTF-8, matching
+ * rss-parser's own behavior.
+ */
+const decodeBody = (buffer: ArrayBuffer, contentType: string | null): string => {
+  const charset = /charset=([^;]+)/i.exec(contentType ?? "")?.[1]?.trim();
+  try {
+    return new TextDecoder(charset || "utf-8").decode(buffer);
+  } catch {
+    return new TextDecoder("utf-8").decode(buffer);
+  }
+};
 
 const getFeed = async (feed: string): Promise<{ items: any[] } | null> => {
   console.log("Parsing feed:", feed);
   try {
-    return await parser.parseURL(feed);
+    const response = await fetch(feed, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      headers: FETCH_HEADERS,
+      redirect: "follow",
+    });
+
+    if (!response.ok) {
+      // Release the connection before bailing; the message format matches
+      // rss-parser's so the status-code handling below keeps working.
+      await response.body?.cancel().catch(() => {});
+      throw new Error(`Status code ${response.status}`);
+    }
+
+    const xml = decodeBody(
+      await response.arrayBuffer(),
+      response.headers.get("content-type")
+    );
+    return await parser.parseString(xml);
   } catch (error: any) {
     const statusMatch = error?.message?.match(/Status code (\d+)/);
     const statusCode = statusMatch ? statusMatch[1] : null;
 
     if (statusCode === "503" || statusCode === "502" || statusCode === "504") {
       console.warn(`Feed temporarily unavailable (${statusCode}): ${feed}`);
+    } else if (error?.name === "TimeoutError") {
+      console.warn(`Feed timed out after ${FETCH_TIMEOUT_MS}ms: ${feed}`);
     } else {
       console.error(`Failed to fetch feed ${feed}:`, error?.message || error);
     }

--- a/src/helper/getFeed.ts
+++ b/src/helper/getFeed.ts
@@ -20,7 +20,10 @@ const parser = new Parser();
  * (some German feeds still serve ISO-8859-1); falls back to UTF-8, matching
  * rss-parser's own behavior.
  */
-const decodeBody = (buffer: ArrayBuffer, contentType: string | null): string => {
+const decodeBody = (
+  buffer: ArrayBuffer,
+  contentType: string | null,
+): string => {
   const charset = /charset=([^;]+)/i.exec(contentType ?? "")?.[1]?.trim();
   try {
     return new TextDecoder(charset || "utf-8").decode(buffer);
@@ -47,7 +50,7 @@ const getFeed = async (feed: string): Promise<{ items: any[] } | null> => {
 
     const xml = decodeBody(
       await response.arrayBuffer(),
-      response.headers.get("content-type")
+      response.headers.get("content-type"),
     );
     return await parser.parseString(xml);
   } catch (error: any) {

--- a/src/helper/hashtagGenerator.ts
+++ b/src/helper/hashtagGenerator.ts
@@ -4,7 +4,10 @@ import { parseAiJson } from "./parseAiJson.js";
 
 let _anthropicClient: Anthropic | null = null;
 function getAnthropicClient(apiKey: string): Anthropic {
-  if (!_anthropicClient) _anthropicClient = new Anthropic({ apiKey });
+  // SDK defaults (10 min timeout × 2 retries) can pin a worker far past
+  // Bree's 300s force-kill; callers all degrade gracefully on error.
+  if (!_anthropicClient)
+    _anthropicClient = new Anthropic({ apiKey, timeout: 60_000, maxRetries: 1 });
   return _anthropicClient;
 }
 

--- a/src/helper/login.test.ts
+++ b/src/helper/login.test.ts
@@ -31,6 +31,7 @@ describe("login", () => {
     expect(mockCreateRestAPIClient).toHaveBeenCalledWith({
       url: "https://mastodon.example",
       accessToken: "test-token",
+      timeout: 30_000,
     });
   });
 

--- a/src/helper/login.ts
+++ b/src/helper/login.ts
@@ -1,9 +1,16 @@
 import { createRestAPIClient } from "masto";
 
+// Without an explicit timeout masto applies none at all, so a stalled
+// Mastodon connection is only cut by undici's 300s headers timeout — the
+// same instant Bree force-kills the worker. Keep every API call well below
+// that window; jobs already tolerate masto errors.
+const REQUEST_TIMEOUT_MS = 30_000;
+
 const getInstance = async () => {
   return await createRestAPIClient({
     url: process.env.API_INSTANCE as string,
     accessToken: process.env.ACCESS_TOKEN as string,
+    timeout: REQUEST_TIMEOUT_MS,
   });
 };
 

--- a/src/helper/questionAnswerer.ts
+++ b/src/helper/questionAnswerer.ts
@@ -4,7 +4,10 @@ import { hasAiBudgetForSource, logAiUsage } from "./costTracker.js";
 
 let _anthropicClient: Anthropic | null = null;
 function getAnthropicClient(apiKey: string): Anthropic {
-  if (!_anthropicClient) _anthropicClient = new Anthropic({ apiKey });
+  // SDK defaults (10 min timeout × 2 retries) can pin a worker far past
+  // Bree's 300s force-kill; callers all degrade gracefully on error.
+  if (!_anthropicClient)
+    _anthropicClient = new Anthropic({ apiKey, timeout: 60_000, maxRetries: 1 });
   return _anthropicClient;
 }
 

--- a/src/helper/regionalRelevance.ts
+++ b/src/helper/regionalRelevance.ts
@@ -10,7 +10,10 @@ import {
 
 let _anthropicClient: Anthropic | null = null;
 function getAnthropicClient(apiKey: string): Anthropic {
-  if (!_anthropicClient) _anthropicClient = new Anthropic({ apiKey });
+  // SDK defaults (10 min timeout × 2 retries) can pin a worker far past
+  // Bree's 300s force-kill; callers all degrade gracefully on error.
+  if (!_anthropicClient)
+    _anthropicClient = new Anthropic({ apiKey, timeout: 60_000, maxRetries: 1 });
   return _anthropicClient;
 }
 

--- a/src/helper/semanticSimilarity.ts
+++ b/src/helper/semanticSimilarity.ts
@@ -9,7 +9,10 @@ import {
 
 let _anthropicClient: Anthropic | null = null;
 function getAnthropicClient(apiKey: string): Anthropic {
-  if (!_anthropicClient) _anthropicClient = new Anthropic({ apiKey });
+  // SDK defaults (10 min timeout × 2 retries) can pin a worker far past
+  // Bree's 300s force-kill; callers all degrade gracefully on error.
+  if (!_anthropicClient)
+    _anthropicClient = new Anthropic({ apiKey, timeout: 60_000, maxRetries: 1 });
   return _anthropicClient;
 }
 

--- a/src/jobs/cleanup-duplicates.ts
+++ b/src/jobs/cleanup-duplicates.ts
@@ -24,10 +24,14 @@ const MIN_AGE_MINUTES = 5; // Only consider toots older than 5 minutes
 const REQUEST_DELAY = 500; // Delay between API requests
 const DELETE_DELAY = 1500; // Delay between deletions
 
-// Rate limiting
+// Rate limiting. The full backoff chain must stay well below Bree's 300s
+// closeWorkerAfterMs (5s+10s+20s = 35s worst case per call) so the
+// "Max retries exceeded" path — which stops the run and posts "done" —
+// is actually reachable instead of the worker being force-killed mid-sleep.
+// The old budget (10 retries, 755s cumulative) guaranteed a force-kill.
 const INITIAL_RETRY_DELAY = 5000;
-const MAX_RETRY_DELAY = 120000;
-const MAX_RETRIES = 10;
+const MAX_RETRY_DELAY = 30000;
+const MAX_RETRIES = 3;
 
 function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));

--- a/src/jobs/cleanup.ts
+++ b/src/jobs/cleanup.ts
@@ -285,7 +285,12 @@ async function runFullCleanup(): Promise<CleanupStats> {
 
   if (parentPort) parentPort.postMessage("done");
   else process.exit(0);
-})();
+})().catch((err) => {
+  // Bree worker contract: "done" must be posted on every exit path.
+  console.error("[cleanup] Fatal error:", err);
+  if (parentPort) parentPort.postMessage("done");
+  else process.exit(1);
+});
 
 // Export for use in other modules (inline cleanup after tooting)
 export { cleanupTootedArticles, cleanupOrphanedStoryRefs, runFullCleanup };

--- a/src/jobs/daily-digest.ts
+++ b/src/jobs/daily-digest.ts
@@ -98,4 +98,9 @@ function getDateBerlin(date: string): string {
 
   if (parentPort) parentPort.postMessage("done");
   else process.exit(0);
-})();
+})().catch((err) => {
+  // Bree worker contract: "done" must be posted on every exit path.
+  console.error("[daily-digest] Fatal error:", err);
+  if (parentPort) parentPort.postMessage("done");
+  else process.exit(1);
+});

--- a/src/jobs/feed-grabber.ts
+++ b/src/jobs/feed-grabber.ts
@@ -255,4 +255,9 @@ async function fetchFeedBatch(
 
   if (parentPort) parentPort.postMessage("done");
   else process.exit(0);
-})();
+})().catch((err) => {
+  // Bree worker contract: "done" must be posted on every exit path.
+  console.error("[feed-grabber] Fatal error:", err);
+  if (parentPort) parentPort.postMessage("done");
+  else process.exit(1);
+});

--- a/src/jobs/feed-tooter.ts
+++ b/src/jobs/feed-tooter.ts
@@ -667,4 +667,9 @@ type StoryInfo = {
 
   if (parentPort) parentPort.postMessage("done");
   else process.exit(0);
-})();
+})().catch((err) => {
+  // Bree worker contract: "done" must be posted on every exit path.
+  console.error("[feed-tooter] Fatal error:", err);
+  if (parentPort) parentPort.postMessage("done");
+  else process.exit(1);
+});

--- a/src/jobs/story-thread-fixer.ts
+++ b/src/jobs/story-thread-fixer.ts
@@ -38,11 +38,23 @@ const TIME_WINDOW_HOURS = 24; // Only group toots within 24 hours of each other
 const MAX_CLUSTERS_PER_RUN = 3; // Limit fixes per run to avoid rate limits
 const MAX_CLUSTER_SIZE = settings.thread_fixer_max_cluster_size ?? 4;
 
-// Rate limiting
+// Rate limiting. All in-worker waits must stay well below Bree's 300s
+// closeWorkerAfterMs — the previous 30-min pause guaranteed the worker was
+// force-killed mid-sleep, so its "resume" code was unreachable. On sustained
+// 429s we now stop the run cleanly; the next scheduled run (12h later, far
+// beyond Mastodon's ~5-min rate-limit window) picks up remaining clusters.
 const REQUEST_DELAY_MS = 2000; // 2 seconds between API calls
 const DELETE_DELAY_MS = 3000; // 3 seconds between deletions
-const RATE_LIMIT_PAUSE_MS = 30 * 60 * 1000; // 30 minutes on rate limit
+const RATE_LIMIT_RETRY_MS = 45 * 1000; // single bounded wait before the one 429 retry
+const RETRY_DELAY_MS = 30 * 1000; // between cluster retries (non-429 errors)
 const MAX_RETRIES = 3;
+
+/** Thrown to abort the whole run when Mastodon keeps rate-limiting us. */
+class RateLimitAbortError extends Error {
+  constructor() {
+    super("aborting run: rate limited");
+  }
+}
 
 interface TootInfo extends ClusterableToot {
   content: string;
@@ -146,12 +158,16 @@ async function fixCluster(
       return { deleted: 0, replied: 0, failed: 0 };
     }
   } catch (err: any) {
+    if (err.statusCode === 429) throw new RateLimitAbortError();
     console.error(`  Failed to verify primary: ${err.message}`);
     failed++;
     return { deleted, replied, failed };
   }
 
   for (const dup of cluster.duplicates) {
+    // Phase 1: nothing destructive has happened yet — on 429 abort the whole
+    // run; the next scheduled run re-clusters and redoes this work.
+    let replyText: string | null = null;
     try {
       // SAFETY: Re-verify this duplicate has no interactions before deleting
       console.log(`  Re-checking ${dup.id} for interactions...`);
@@ -165,30 +181,33 @@ async function fixCluster(
         continue;
       }
 
-      // Extract unique links not in primary
+      // Extract unique links not in primary; without new links the duplicate
+      // is deleted and nothing needs re-posting. Reply text uses the same
+      // prefix as feed-tooter follow-ups, so tootClustering's isUpdatePost
+      // catches both.
       const primaryLinks = new Set(cluster.primary.links);
       const newLinks = dup.links.filter((link) => !primaryLinks.has(link));
-
-      if (newLinks.length === 0) {
-        // No new links - just delete without re-posting
-        console.log(`  Deleting ${dup.id} (no new links)...`);
-        await client.v1.statuses.$select(dup.id).remove();
-        deleted++;
-        await sleep(DELETE_DELAY_MS);
-        continue;
+      if (newLinks.length > 0) {
+        replyText = `🔗 Update: ${dup.headline.slice(0, 200)}\n${newLinks.slice(0, 2).join("\n")}`;
       }
 
-      // Build reply text with headline context and new links (same prefix as
-      // feed-tooter follow-ups, so tootClustering's isUpdatePost catches both)
-      const replyText = `🔗 Update: ${dup.headline.slice(0, 200)}\n${newLinks.slice(0, 2).join("\n")}`;
-
-      // Delete the duplicate
-      console.log(`  Deleting ${dup.id}...`);
+      console.log(`  Deleting ${dup.id}${replyText === null ? " (no new links)" : ""}...`);
       await client.v1.statuses.$select(dup.id).remove();
       deleted++;
       await sleep(DELETE_DELAY_MS);
+    } catch (err: any) {
+      if (err.statusCode === 429) throw new RateLimitAbortError();
+      console.error(`  Failed to process ${dup.id}: ${err.message}`);
+      failed++;
+      continue;
+    }
 
-      // Re-post as reply
+    if (replyText === null) continue;
+
+    // Phase 2: the duplicate is already deleted — if the reply never lands,
+    // its links are lost. One bounded retry on 429 (must stay far below
+    // Bree's 300s force-kill), then give up loudly.
+    try {
       console.log(`  Creating reply to ${cluster.primary.id}...`);
       await client.v1.statuses.create({
         status: replyText,
@@ -199,21 +218,29 @@ async function fixCluster(
       replied++;
       await sleep(REQUEST_DELAY_MS);
     } catch (err: any) {
-      if (err.statusCode === 429) {
-        console.log(
-          `[story-thread-fixer] Rate limited! Waiting ${RATE_LIMIT_PAUSE_MS / 60000} minutes...`
-        );
-        await sleep(RATE_LIMIT_PAUSE_MS);
-        // Retry this one
-        try {
-          await client.v1.statuses.$select(dup.id).remove();
-          deleted++;
-        } catch {
-          failed++;
-        }
-      } else {
-        console.error(`  Failed to process ${dup.id}: ${err.message}`);
+      if (err.statusCode !== 429) {
+        console.error(`  Reply for deleted toot ${dup.id} failed (links lost): ${err.message}`);
         failed++;
+        continue;
+      }
+      console.log(
+        `[story-thread-fixer] Rate limited after deleting ${dup.id} — one retry in ${RATE_LIMIT_RETRY_MS / 1000}s...`
+      );
+      await sleep(RATE_LIMIT_RETRY_MS);
+      try {
+        await client.v1.statuses.create({
+          status: replyText,
+          inReplyToId: cluster.primary.id,
+          visibility: "public",
+          language: "de",
+        });
+        replied++;
+      } catch (retryErr: any) {
+        console.error(
+          `  Reply for deleted toot ${dup.id} failed after retry (links lost): ${retryErr.message}`
+        );
+        failed++;
+        throw new RateLimitAbortError();
       }
     }
   }
@@ -262,7 +289,9 @@ async function fixCluster(
     let totalReplied = 0;
     let totalFailed = 0;
 
-    for (let i = 0; i < clustersToFix.length; i++) {
+    let rateLimited = false;
+
+    for (let i = 0; i < clustersToFix.length && !rateLimited; i++) {
       console.log(
         `\n[story-thread-fixer] Processing cluster ${i + 1}/${clustersToFix.length}...`
       );
@@ -278,12 +307,21 @@ async function fixCluster(
           totalFailed += result.failed;
           success = true;
         } catch (err: any) {
+          if (err instanceof RateLimitAbortError) {
+            // Don't wait out a rate limit inside the worker — the next
+            // scheduled run (12h away) is far past any rate-limit window.
+            console.log(
+              "[story-thread-fixer] Rate limited — stopping this run; remaining clusters will be handled next run"
+            );
+            rateLimited = true;
+            break;
+          }
           retries++;
           console.error(
             `[story-thread-fixer] Cluster failed (retry ${retries}/${MAX_RETRIES}): ${err.message}`
           );
           if (retries < MAX_RETRIES) {
-            await sleep(RATE_LIMIT_PAUSE_MS / 6); // 5 min between retries
+            await sleep(RETRY_DELAY_MS);
           }
         }
       }

--- a/src/jobs/weekly-digest.ts
+++ b/src/jobs/weekly-digest.ts
@@ -105,4 +105,9 @@ function getSevenDaysAgoBerlin(): string {
 
   if (parentPort) parentPort.postMessage("done");
   else process.exit(0);
-})();
+})().catch((err) => {
+  // Bree worker contract: "done" must be posted on every exit path.
+  console.error("[weekly-digest] Fatal error:", err);
+  if (parentPort) parentPort.postMessage("done");
+  else process.exit(1);
+});


### PR DESCRIPTION
## Description

Investigation into the linearly-growing memory on Railway. The investigation first **re-tested the standing theory from `docs/operations.md`** (Node worker-churn leak): a churn test against the exact production binary (v24.10.0) with the real dependency graph and Bree's exact lifecycle — including a 700-consecutive-force-kill variant — showed **flat parent RSS**, identical to 24.16. A release-by-release review of v24.11.0–v24.16.0 confirmed no worker_threads memory fix landed in that window. So the Node version is not the culprit, and upgrading is not a memory fix (24.16.0 actually ships a known fetch leak *regression*, nodejs/node#63708/#63574).

What the audit did find is a class of real problems: **workers pinned past Bree's 300s force-kill window by unbounded waits**. A hung worker holds its full dependency-graph heap (~50–100 MB) plus live TLS sockets until the kill; overlapping hung workers raise the container's memory baseline. Fixes:

- **`story-thread-fixer`**: slept 30 min in-worker on HTTP 429 (and 5 min between retries) — every rate-limited run was *guaranteed* force-killed mid-sleep, and the unreachable "resume" code retried the wrong operation (re-deleting an already-deleted toot instead of re-posting its reply), silently losing the deleted duplicate's links. Now aborts the run cleanly on sustained 429s and does one bounded 45s retry of the *reply* when the duplicate is already deleted.
- **`cleanup-duplicates`**: retry backoff summed to 755s across 10 retries, crossing the kill window mid-sleep; now 3 retries / 35s total so the graceful stop path is actually reachable.
- **masto client**: had no timeout at all — calls were bounded only by undici's 300s headers timeout, the exact force-kill instant. Now 30s.
- **Anthropic SDK**: default 10-min timeout × 2 retries (~30 min worst case) on all five AI helpers, awaited on the only path to `postMessage("done")` in the three highest-frequency jobs. Now 60s × 1 retry.
- **RSS feeds**: rss-parser's `parseURL` never destroys the request on timeout, non-2xx, or redirect (rbren/rss-parser#238, unfixed upstream) — the socket stays open and keeps buffering. `getFeed` now fetches the XML via native fetch with `AbortSignal.timeout` (which really aborts the transfer, charset decoding preserved) and uses rss-parser only for parsing.
- **`fetchImage`**: cleared its abort timer once headers arrived, so a slow-drip body could hold a worker open indefinitely; one deadline now covers headers + body.
- **All bare-IIFE jobs** (feed-grabber, feed-tooter, cleanup, both digests): a crash now still posts `"done"` per the Bree worker contract instead of dying as an unhandled rejection.
- **Docs**: `docs/operations.md` corrected (24.10.0 measured clean; don't chase Node versions; warning about 24.16.0) and now documents the per-dependency timeout table plus how to read the hourly `[memory]` telemetry line to classify any residual growth (`rss`/`anon` climbing = process leak; `file` climbing = page cache; `workersAlive` > 0 = hung workers).

## Related Issue

None filed — reported directly: container memory on Railway grows linearly until restart.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist

- [x] Tests pass (`npm test`) — 618/618
- [x] Types check (`npm run typecheck`)
- [x] Code is formatted — touched files that were prettier-clean stay clean (several touched job files were already unformatted on master; left as-is to avoid noise)
- [x] Self-reviewed the changes
- [x] Updated documentation if needed

## Screenshots (if applicable)

N/A

## Additional Notes

After deploying, the hourly `[memory]` log line (added in 90ec6eb) is the ground truth: if the Railway graph still climbs while `rss`/`anon` stay flat, the growth is page-cache accounting, not a leak. If `rss` climbs, the telemetry now narrows where to look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZjvVGr1ELHLkJtiFxcYNh

---
_Generated by [Claude Code](https://claude.ai/code/session_01TZjvVGr1ELHLkJtiFxcYNh)_